### PR TITLE
[Merged by Bors] - Prevent multiple providers for the 'graphics-core20' content interface

### DIFF
--- a/snap/hooks/prepare-plug-graphics-core20
+++ b/snap/hooks/prepare-plug-graphics-core20
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 if snapctl is-connected graphics-core20; then
-  echo "Multiple providers for the 'graphics-core20' content interface are not supported."
+  echo "Please disconnect the current provider for 'graphics-core20' before connecting a new one"
   exit 1
 fi

--- a/snap/hooks/prepare-plug-graphics-core20
+++ b/snap/hooks/prepare-plug-graphics-core20
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+if snapctl is-connected graphics-core20; then
+  echo "Multiple providers for the 'graphics-core20' content interface are not supported."
+  exit 1
+fi


### PR DESCRIPTION
Give a sensible error when connecting:
```
$ snap connect ubuntu-frame:graphics-core20 mesa-core20_2:graphics-core20
error: cannot perform the following tasks:
- Run hook prepare-plug-graphics-core20 of snap "ubuntu-frame" (run hook "prepare-plug-graphics-core20": Please disconnect the current provider for 'graphics-core20' before connecting a new one)
```
Mitigates: #5