### PR TITLE
Add network-bind interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,8 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core20
+  # network-bind is needed to run via X-forwarding (development in a container or VM)
+  network-bind:
 
 parts:
   recipe-version:


### PR DESCRIPTION
This can be useful during development as it allows Mir on X  via X-forwarding

Fixes: #26