### PR TITLE
Support ubuntu-frame-osk

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,9 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core20
+  on-screen-keyboard-auth:
+    interface: content
+    target: $SNAP/osk-auth
 
 parts:
   recipe-version:


### PR DESCRIPTION
This adds support for using the on-screen keyboard from https://github.com/MirServer/ubuntu-frame-osk. On startup ubuntu-frame-osk creates a file named `osk-auth/allow-####` where `osk-auth` is a directory shared via the `on-screen-keyboard-auth` content interface and `####` is the OSK's PID. This allows Ubuntu Frame to only allow privileged OSK processes to have access to protocols such as layer shell and text input.

The code to move fullscreen surfaces out of the way of attached surfaces will come separately.