### PR TITLE
[Merged by Bors] - snapcraft: use package-repositories key

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,9 +86,6 @@ parts:
       if echo $mir_version | grep -e '+dev' -e '~rc' -q; then snapcraftctl set-grade devel; else snapcraftctl set-grade stable; fi
     plugin: cmake
     source: src
-    override-build: |
-      sudo apt install --assume-yes libmiral-dev
-      snapcraftctl build
     build-packages:
       - pkg-config
       - libmiral-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,6 +6,9 @@ confinement: strict
 base: core20
 license: GPL-3.0
 compression: lzo
+package-repositories:
+  - type: apt
+    ppa: mir-team/release
 
 architectures:
   - build-on: amd64
@@ -73,15 +76,8 @@ parts:
     prime:
       - -recipe-version
 
-  ppa-setup:
-    plugin: nil
-    override-pull: |
-      sudo apt --assume-yes install software-properties-common
-      sudo add-apt-repository -y ppa:mir-team/release
-      snapcraftctl pull
-
   ubuntu-frame:
-    after: [recipe-version, ppa-setup]
+    after: [recipe-version]
     override-pull: |
       snapcraftctl pull
       mir_version=`LANG=C apt-cache policy mir-graphics-drivers-desktop | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
@@ -104,7 +100,6 @@ parts:
       - libapparmor1
 
   platform:
-    after: [ppa-setup]
     plugin: nil
     stage-packages:
       - mir-platform-graphics-gbm-kms


### PR DESCRIPTION
Instead of manual ppa-setup, use the now supported for a while
package-repositories key to enable mir-team's ppa.