### PR TITLE
snapcraft: stage eglstream-kms platform

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,6 +109,7 @@ parts:
     stage-packages:
       - mir-platform-graphics-gbm-kms
       - mir-platform-graphics-x
+      - mir-platform-graphics-eglstream-kms
     prime:
       - usr/lib/${SNAPCRAFT_ARCH_TRIPLET}
       - usr/share/libinput


### PR DESCRIPTION
Stage eglstream-kms platform, such that ubuntu-frame can try to use it on suitable systems.