### PR TITLE
[Merged by Bors] - Daemons should point $HOME at $SNAP_DATA

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,7 @@ apps:
     environment:
       # XDG config
       XDG_CONFIG_HOME: $SNAP_DATA
+      HOME: $SNAP_DATA
     plugs:
       - opengl
     slots:


### PR DESCRIPTION
A (reasonable) suggestions from `@ogra`

https://forum.snapcraft.io/t/mir-kiosk-fails-to-start-only-black-screen-appears-and-no-orangish-fade-pops-up/22670/5