### PR TITLE
[Merged by Bors] - Add x11-window-title option

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -73,6 +73,7 @@ config_entry "console-provider"   "vt"                                  "Require
 config_entry "vt"                 "4"                                   "Virtual terminal to use for display (0 to use current)"
 config_entry "cursor"             "auto"                                "Mouse pointer to use (auto|none|software)"
 config_entry "env-hacks"          "MIR_MESA_KMS_DISABLE_MODESET_PROBE"  "As Frame HAS to run mesa-kms we can safely override the probe for KMS everywhere"
+config_entry "x11-window-title"   "Ubuntu Frame"                        "Default window title when run as Mir on X"
 
 if ! diff "${config_temp}" "${config_file}" > /dev/null; then
   mv "${config_file}"  "${config_file}.save" || true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ license: GPL-3.0
 compression: lzo
 package-repositories:
   - type: apt
-    ppa: mir-team/dev
+    ppa: mir-team/release
 
 architectures:
   - build-on: amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ license: GPL-3.0
 compression: lzo
 package-repositories:
   - type: apt
-    ppa: mir-team/release
+    ppa: mir-team/dev
 
 architectures:
   - build-on: amd64


### PR DESCRIPTION
Adds the x11-window-title option from Mir. Defaults to "Ubuntu Frame".