### PR TITLE
[Merged by Bors] - add hardware-observe plug 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ apps:
       - login-session-control # to run as a user login (e.g. from a VT)
       - x11                   # to run on a host X11 server
       - network-bind          # to run via X-forwarding (e.g. development in a container/VM)
+      - hardware-observe      # libinput likes to scan udev
     slots:
       - wayland
 
@@ -57,7 +58,7 @@ apps:
       XDG_CONFIG_HOME: $SNAP_DATA
       HOME: $SNAP_DATA
     plugs:
-      - hardware-observe
+      - hardware-observe      # libinput likes to scan udev
       - opengl
     slots:
       - wayland

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,7 @@ apps:
       XDG_CONFIG_HOME: $SNAP_DATA
       HOME: $SNAP_DATA
     plugs:
+      - hardware-observe
       - opengl
     slots:
       - wayland


### PR DESCRIPTION
add hardware-observe plug to ubuntu-frame.daemon to quieten log spam from libinput when walking /run/udev