### PR TITLE
[Merged by Bors] - Enable input protocols for VNC snap

### DIFF
--- a/src/frame_authorization.cpp
+++ b/src/frame_authorization.cpp
@@ -33,6 +33,8 @@ AuthModel const auth_model{{
     }},
     {"ubuntu-frame-vnc", {
         WaylandExtensions::zwlr_screencopy_manager_v1,
+        WaylandExtensions::zwlr_virtual_pointer_manager_v1,
+        WaylandExtensions::zwp_virtual_keyboard_manager_v1,
     }},
     {"ubuntu-frame", {
         WaylandExtensions::zwlr_screencopy_manager_v1,

--- a/src/frame_authorization.cpp
+++ b/src/frame_authorization.cpp
@@ -18,6 +18,7 @@
 
 #include "frame_authorization.h"
 
+#include <miral/version.h>
 #include <mir/log.h>
 #include <sys/apparmor.h>
 #include <cstring>
@@ -33,7 +34,9 @@ AuthModel const auth_model{{
     }},
     {"ubuntu-frame-vnc", {
         WaylandExtensions::zwlr_screencopy_manager_v1,
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(3, 6, 0)
         WaylandExtensions::zwlr_virtual_pointer_manager_v1,
+#endif
         WaylandExtensions::zwp_virtual_keyboard_manager_v1,
     }},
     {"ubuntu-frame", {


### PR DESCRIPTION
Possibly now that virtual pointer and seat v8 support have landed in Mir. The `ubuntu-frame-vnc` snap still doesn't seem to be trying input, but it's not obvious where that's disabled.