### PR TITLE
[Merged by Bors] - wm: place windows round-robin on all displays

### DIFF
--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2021 Canonical Ltd.
+ * Copyright © 2016-2022 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -90,6 +90,11 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
         WindowInfo window_info{};
         if (override_state(specification, window_info))
         {
+            if (!specification.output_id().is_set() && output_count > 0)
+            {
+                // Place new windows round-robin on all available outputs
+                specification.output_id() = window_count++ % output_count + 1;
+            }
             specification.state() = mir_window_state_maximized;
             tools.place_and_size_for_state(specification, window_info);
             specification.state() = mir_window_state_fullscreen;
@@ -186,4 +191,16 @@ void FrameWindowManagerPolicy::advise_application_zone_delete(Zone const& applic
 {
     WindowManagementPolicy::advise_application_zone_delete(application_zone);
     application_zones_have_changed = true;
+}
+
+void FrameWindowManagerPolicy::advise_output_create(miral::Output const &output)
+{
+    WindowManagementPolicy::advise_output_create(output);
+    output_count++;
+}
+
+void FrameWindowManagerPolicy::advise_output_delete(miral::Output const &output)
+{
+    WindowManagementPolicy::advise_output_delete(output);
+    output_count--;
 }

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -93,7 +93,7 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
             if (!specification.output_id().is_set() && output_count > 0)
             {
                 // Place new windows round-robin on all available outputs
-                specification.output_id() = window_count++ % output_count + 1;
+                specification.output_id() = (window_count++ % output_count) + 1;
             }
             specification.state() = mir_window_state_maximized;
             tools.place_and_size_for_state(specification, window_info);

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -16,8 +16,8 @@
  * Authored By: Alan Griffiths <alan@octopull.co.uk>
  */
 
-#ifndef MIRAL_X11_KIOSK_WINDOW_MANAGER_H
-#define MIRAL_X11_KIOSK_WINDOW_MANAGER_H
+#ifndef FRAME_WINDOW_MANAGER_H
+#define FRAME_WINDOW_MANAGER_H
 
 #include <miral/minimal_window_manager.h>
 
@@ -54,4 +54,4 @@ private:
     unsigned short window_count = 0;
 };
 
-#endif /* MIRAL_X11_KIOSK_WINDOW_MANAGER_H */
+#endif /* FRAME_WINDOW_MANAGER_H */

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -44,9 +44,14 @@ public:
     void advise_application_zone_create(miral::Zone const& application_zone) override;
     void advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original) override;
     void advise_application_zone_delete(miral::Zone const& application_zone) override;
+    void advise_output_create(miral::Output const &output) override;
+    void advise_output_delete(miral::Output const &output) override;
 
 private:
     bool application_zones_have_changed = false;
+    int output_count = 0;
+    // This only used for modulo, so wrap-around is desired
+    unsigned short window_count = 0;
 };
 
 #endif /* MIRAL_X11_KIOSK_WINDOW_MANAGER_H */

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2020 Canonical Ltd.
+ * Copyright © 2016-2022 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as


### PR DESCRIPTION
This is not strictly correct, as overlapping displays and particularly display groups will not get the correct treatment - but is an improvement over the current behaviour.

This requires Mir 2.10 to work.

Also fix copyright and include guard along the way.