### PR TITLE
Check if diagnostic file is in relative path after absolute

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -180,7 +180,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         }
 
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Diagnostic path (" + option_path.parent_path().string() + ") does not exist"));
+            "Diagnostic path (" + relative_path.parent_path().string() + ") does not exist"));
     }
 }
 

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -173,7 +173,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     {
         auto const relative_path = boost::filesystem::current_path().append(option);
 
-        if (exists(relative_path))
+        if (exists(relative_path.parent_path()))
         {
             diagnostic_path = relative_path;
             return;

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -171,6 +171,14 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     }
     else
     {
+        auto const relative_path = boost::filesystem::current_path().append(option);
+
+        if (exists(relative_path))
+        {
+            diagnostic_path = relative_path;
+            return;
+        }
+
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Diagnostic path (" + option_path.parent_path().string() + ") does not exist"));
     }


### PR DESCRIPTION
~~Fixes #93 by clarifying an absolute path is needed for the `--diagnostic-path` option.~~

~~This is if we consider `./` to be a macro that gets an absolute path from a relative path. Not sure how to specify this without getting wordier.~~

Fixes #93 by first checking if file is in absolute path, then attempts relative path if that fails.