### PR TITLE
Fix crash from directory passed as diagnostic file

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -165,7 +165,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     }
     
     auto option_path = Path(option);
-    if (exists(option_path.parent_path()))
+    if (exists(option_path.parent_path()) && boost::filesystem::is_regular_file(option_path))
     {
         diagnostic_path = option_path;
     }
@@ -173,7 +173,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     {
         auto const relative_path = boost::filesystem::current_path().append(option);
 
-        if (exists(relative_path.parent_path()))
+        if (exists(relative_path.parent_path()) && boost::filesystem::is_regular_file(relative_path))
         {
             diagnostic_path = relative_path;
             return;

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -180,7 +180,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         }
 
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Diagnostic path (" + option_path.parent_path().string() + ") does not exist"));
+            "Diagnostic path (" + relative_path.parent_path().string() + ") does not exist"));
     }
 }
 

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -164,16 +164,21 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         return;
     }
     
-    auto option_path = Path(option);
-    // Check if file's parent dir exists, then check that the file is not a directory
-    if (exists(option_path.parent_path()) && !boost::filesystem::is_directory(option_path))
+    if (option.at(0) == '/')
     {
-        diagnostic_path = option_path;
+        auto const absolute_path = Path(option);
+        if (exists(absolute_path.parent_path()) && !boost::filesystem::is_directory(absolute_path))
+        {
+            diagnostic_path = absolute_path;
+            return;
+        }
+
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Diagnostic path (" + option + ") is invalid"));
     }
     else
     {
         auto const relative_path = boost::filesystem::current_path().append(option);
-
         if (exists(relative_path.parent_path()) && !boost::filesystem::is_directory(relative_path))
         {
             diagnostic_path = relative_path;

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -173,7 +173,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     {
         auto const relative_path = boost::filesystem::current_path().append(option);
 
-        if (exists(relative_path))
+        if (exists(relative_path.parent_path()))
         {
             diagnostic_path = relative_path;
             return;

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -165,7 +165,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     }
     
     auto option_path = Path(option);
-    if (exists(option_path.parent_path()) && boost::filesystem::is_regular_file(option_path))
+    if (boost::filesystem::is_regular_file(option_path))
     {
         diagnostic_path = option_path;
     }
@@ -173,7 +173,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     {
         auto const relative_path = boost::filesystem::current_path().append(option);
 
-        if (exists(relative_path.parent_path()) && boost::filesystem::is_regular_file(relative_path))
+        if (boost::filesystem::is_regular_file(relative_path))
         {
             diagnostic_path = relative_path;
             return;

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -359,7 +359,6 @@ void BackgroundClient::Self::draw_screen(SurfaceInfo& info, bool draws_crash) co
 
     if (draws_crash || file_exists)
     {
-        draws_crash = true;
         render_background(width, height, buffer, crash_background_colour);
         render_text(width, height, buffer);
     }

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -171,6 +171,14 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     }
     else
     {
+        auto const relative_path = boost::filesystem::current_path().append(option);
+
+        if (exists(relative_path))
+        {
+            diagnostic_path = relative_path;
+            return;
+        }
+
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Diagnostic path (" + option_path.parent_path().string() + ") does not exist"));
     }

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -180,7 +180,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         }
 
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Diagnostic path (" + relative_path.parent_path().string() + ") does not exist"));
+            "Diagnostic path (" + relative_path.string() + ") is invalid"));
     }
 }
 

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -165,7 +165,8 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     }
     
     auto option_path = Path(option);
-    if (boost::filesystem::is_regular_file(option_path))
+    // Check if file's parent dir exists, then check that the file is not a directory
+    if (exists(option_path.parent_path()) && !boost::filesystem::is_directory(option_path))
     {
         diagnostic_path = option_path;
     }
@@ -173,7 +174,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     {
         auto const relative_path = boost::filesystem::current_path().append(option);
 
-        if (boost::filesystem::is_regular_file(relative_path))
+        if (exists(relative_path.parent_path()) && !boost::filesystem::is_directory(relative_path))
         {
             diagnostic_path = relative_path;
             return;


### PR DESCRIPTION
This fixes what I believe was causing #94 but is still needed whether or not that was the problem. Frame will crash if a directory is passed as a path ending in a filename to `--diagnostic-path`