### PR TITLE
[Merged by Bors] - Reset timer when windows closed

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -46,8 +46,9 @@ auto get_font_path() -> Path
 }
 } // namespace
 
-BackgroundClient::BackgroundClient(miral::MirRunner* runner)
-: runner{runner}
+BackgroundClient::BackgroundClient(miral::MirRunner* runner, WindowManagerObserver* window_manager_observer)
+: runner{runner},
+  window_manager_observer{window_manager_observer}
 {
 }
 
@@ -124,11 +125,6 @@ TextRenderer::~TextRenderer()
         mir::log_warning("Failed to uninitialize FreeType with error %d", error);
     }
     library = nullptr;
-}
-
-void BackgroundClient::set_window_manager_observer(WindowManagerObserver* window_manager_observer)
-{
-    this->window_manager_observer = window_manager_observer;
 }
 
 void BackgroundClient::set_colour(std::string const& option, Colour& colour)

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -57,6 +57,7 @@ public:
     Self(
         wl_display* display,
         miral::MirRunner* runner,
+        WindowManagerObserver* window_manager_observer,
         Colour const& wallpaper_top_colour,
         Colour const& wallpaper_bottom_colour,
         Colour const& crash_background_colour,
@@ -123,6 +124,11 @@ TextRenderer::~TextRenderer()
         mir::log_warning("Failed to uninitialize FreeType with error %d", error);
     }
     library = nullptr;
+}
+
+void BackgroundClient::set_window_manager_observer(WindowManagerObserver* window_manager_observer)
+{
+    this->window_manager_observer = window_manager_observer;
 }
 
 void BackgroundClient::set_colour(std::string const& option, Colour& colour)
@@ -238,6 +244,7 @@ void BackgroundClient::operator()(wl_display* display)
     auto client = std::make_shared<Self>(
         display, 
         runner,
+        window_manager_observer,
         wallpaper_top_colour, 
         wallpaper_bottom_colour, 
         crash_background_colour,
@@ -263,13 +270,14 @@ void BackgroundClient::operator()(std::weak_ptr<mir::scene::Session> const& /*se
 BackgroundClient::Self::Self(
     wl_display* display,
     miral::MirRunner* runner,
+    WindowManagerObserver* window_manager_observer,
     Colour const& wallpaper_top_colour,
     Colour const& wallpaper_bottom_colour,
     Colour const& crash_background_colour,
     Colour const& crash_text_colour,
     std::optional<Path> diagnostic_path,
     uint diagnostic_delay)
-    : FullscreenClient(display, diagnostic_path, diagnostic_delay, runner),
+    : FullscreenClient(display, diagnostic_path, diagnostic_delay, runner, window_manager_observer),
       runner{runner},
       wallpaper_top_colour{wallpaper_top_colour},
       wallpaper_bottom_colour{wallpaper_bottom_colour},

--- a/src/background_client.h
+++ b/src/background_client.h
@@ -42,9 +42,8 @@ class WindowManagerObserver;
 class BackgroundClient
 {
 public:
-    BackgroundClient(miral::MirRunner* runner);
+    BackgroundClient(miral::MirRunner* runner, WindowManagerObserver* window_manager_observer);
 
-    void set_window_manager_observer(WindowManagerObserver* window_manager_observer);
     void set_wallpaper_top_colour(std::string const& option);
     void set_wallpaper_bottom_colour(std::string const& option);
     void set_crash_background_colour(std::string const& option);

--- a/src/background_client.h
+++ b/src/background_client.h
@@ -37,11 +37,14 @@ using Colour = unsigned char[4];
 
 namespace miral { class MirRunner; }
 
+class WindowManagerObserver;
+
 class BackgroundClient
 {
 public:
     BackgroundClient(miral::MirRunner* runner);
 
+    void set_window_manager_observer(WindowManagerObserver* window_manager_observer);
     void set_wallpaper_top_colour(std::string const& option);
     void set_wallpaper_bottom_colour(std::string const& option);
     void set_crash_background_colour(std::string const& option);
@@ -70,6 +73,7 @@ public:
 
 private:
     miral::MirRunner* const runner;
+    WindowManagerObserver* window_manager_observer;
 
     std::mutex mutable mutex;
 

--- a/src/egfullscreenclient.cpp
+++ b/src/egfullscreenclient.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "egfullscreenclient.h"
+#include "frame_window_manager.h"
 
 #include <wayland-client.h>
 
@@ -139,13 +140,14 @@ void egmde::FullscreenClient::Output::done(void* data, struct wl_output* /*wl_ou
     output->on_done(*output);
 }
 
-egmde::FullscreenClient::FullscreenClient(wl_display* display, std::optional<Path> diagnostic_path, uint diagnostic_delay, miral::MirRunner* runner) :
+egmde::FullscreenClient::FullscreenClient(wl_display* display, std::optional<Path> diagnostic_path, uint diagnostic_delay, miral::MirRunner* runner, WindowManagerObserver* window_manager_observer) :
     flush_signal{::eventfd(0, EFD_SEMAPHORE)},
     shutdown_signal{::eventfd(0, EFD_CLOEXEC)},
     diagnostic_signal{inotify_init()},
     diagnostic_path{diagnostic_path},
     diagnostic_delay{diagnostic_delay},
     runner{runner},
+    window_manager_observer{window_manager_observer},
     registry{nullptr, [](auto){}}
 {
     // Check inotify initializaiton
@@ -183,6 +185,8 @@ egmde::FullscreenClient::FullscreenClient(wl_display* display, std::optional<Pat
     wl_registry_add_listener(registry.get(), &registry_listener, this);
 
     set_diagnostic_delay_alarm();
+    window_manager_observer->add_window_opened_callback([this]() { diagnostic_wants_to_draw = false; draw(); });
+    window_manager_observer->add_window_closed_callback([this]() { set_diagnostic_delay_alarm(); });
 }
 
 void egmde::FullscreenClient::notify_diagnostic_delay_expired()

--- a/src/egfullscreenclient.h
+++ b/src/egfullscreenclient.h
@@ -260,7 +260,7 @@ private:
     miral::MirRunner* const runner;
     WindowManagerObserver* const window_manager_observer;
 
-    bool diagnostic_delay_expired = false;
+    bool diagnostic_wants_to_draw = false;
     bool diagnostic_exists = false;
 };
 }

--- a/src/egfullscreenclient.h
+++ b/src/egfullscreenclient.h
@@ -42,6 +42,8 @@ namespace miral {
     class FdHandle; 
 }
 
+class WindowManagerObserver;
+
 namespace egmde
 {
 class FullscreenClient
@@ -49,7 +51,12 @@ class FullscreenClient
 public:
     using Path = boost::filesystem::path;
 
-    explicit FullscreenClient(wl_display* display, std::optional<Path> diagnostic_path, uint diagnostic_delay, miral::MirRunner* runner);
+    explicit FullscreenClient(
+        wl_display* display, 
+        std::optional<Path> diagnostic_path,
+        uint diagnostic_delay,
+        miral::MirRunner* runner,
+        WindowManagerObserver* window_manager_observer);
 
     virtual ~FullscreenClient();
 
@@ -251,6 +258,7 @@ private:
     #endif
 
     miral::MirRunner* const runner;
+    WindowManagerObserver* const window_manager_observer;
 
     bool diagnostic_delay_expired = false;
     bool diagnostic_exists = false;

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -39,6 +39,9 @@ int main(int argc, char const* argv[])
 
     BackgroundClient background_client(&runner);
 
+    WindowManagerObserver window_manager_observer{};
+    background_client.set_window_manager_observer(&window_manager_observer);
+
     runner.add_stop_callback([&] { background_client.stop(); });
     
     return runner.run_with(
@@ -61,7 +64,7 @@ int main(int argc, char const* argv[])
             StartupInternalClient{std::ref(background_client)},
             ConfigurationOption{[&](bool option) { init_authorise_without_apparmor(option);},
                                "authorise-without-apparmor", "Use /proc/<pid>/cmdline if AppArmor is unavailable", false },
-            set_window_management_policy<FrameWindowManagerPolicy>(),
+            set_window_management_policy<FrameWindowManagerPolicy>(window_manager_observer),
             Keymap{}
         });
 }

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -32,15 +32,13 @@ int main(int argc, char const* argv[])
 {
     using namespace miral;
     MirRunner runner{argc, argv};
+    WindowManagerObserver window_manager_observer{};
 
     DisplayConfiguration display_config{runner};
     WaylandExtensions wayland_extensions;
     init_authorization(wayland_extensions, auth_model);
 
-    BackgroundClient background_client(&runner);
-
-    WindowManagerObserver window_manager_observer{};
-    background_client.set_window_manager_observer(&window_manager_observer);
+    BackgroundClient background_client(&runner, &window_manager_observer);
 
     runner.add_stop_callback([&] { background_client.stop(); });
     

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -154,8 +154,6 @@ bool FrameWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* eve
 auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info, WindowSpecification const& request)
 -> WindowSpecification
 {
-    window_manager_observer.process_window_opened_callbacks();
-
     WindowSpecification specification = MinimalWindowManager::place_new_window(app_info, request);
 
     {
@@ -179,6 +177,10 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
     if (pid_of(app_info.application()) == getpid())
     {
         specification.depth_layer() = mir_depth_layer_background;
+    }
+    else
+    {
+        window_manager_observer.process_window_opened_callbacks();
     }
 
     return specification;


### PR DESCRIPTION
Fixes #95 by making Frame aware of how many windows are opened and closed in the window manager. When a window is opened, the default wallpaper is displayed in the background. When all windows are closed, the diagnostic delay timer is reset.