### PR TITLE
Separate paths for relative and absolute diagnostic path

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -173,15 +173,29 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         return;
     }
     
-    auto option_path = Path(option);
-    if (exists(option_path.parent_path()))
+    if (option.at(0) == '/')
     {
-        diagnostic_path = option_path;
+        auto const absolute_path = Path(option);
+        if (exists(absolute_path.parent_path()) && !boost::filesystem::is_directory(absolute_path))
+        {
+            diagnostic_path = absolute_path;
+            return;
+        }
+
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Diagnostic path (" + option + ") is invalid"));
     }
     else
     {
+        auto const relative_path = boost::filesystem::current_path().append(option);
+        if (exists(relative_path.parent_path()) && !boost::filesystem::is_directory(relative_path))
+        {
+            diagnostic_path = relative_path;
+            return;
+        }
+
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Diagnostic path (" + option_path.parent_path().string() + ") does not exist"));
+            "Diagnostic path (" + relative_path.string() + ") is invalid"));
     }
 }
 

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -379,17 +379,7 @@ void BackgroundClient::Self::draw_screen(SurfaceInfo& info, bool draws_crash) co
 
     auto buffer = static_cast<unsigned char*>(info.content_area);
 
-    // Don't draw diagnostic background if file is empty or font not found
-    bool file_exists;
-    if (boost::filesystem::exists(diagnostic_path.value_or("")))
-    {
-        file_exists = boost::filesystem::file_size(diagnostic_path.value());
-    }
-    else
-    {
-        file_exists = false;
-    }
-
+    bool file_exists = boost::filesystem::is_regular_file(diagnostic_path.value_or(""));
     if (draws_crash && file_exists)
     {
         render_background(width, height, buffer, crash_background_colour);


### PR DESCRIPTION
Fixes both #93 and #94 by clearly separating the codepaths for absolute and relative path checks on `--diagnostic-path`. The absolute code path is triggered if the path starts with a `/`. Otherwise, it assumes a relative path was provided.