### PR TITLE
Use `boost::filesystem::canonical()` to fix diagnostic path issues

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -175,16 +175,14 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         return;
     }
     
-    auto option_path = Path(option);
-    if (exists(option_path.parent_path()))
-    {
-        diagnostic_path = option_path;
-    }
-    else
+    auto path = boost::filesystem::canonical(option);
+    if (boost::filesystem::is_directory(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Diagnostic path (" + option_path.parent_path().string() + ") does not exist"));
+            "Target of diagnostic path (" + path.string() + ") is a directory when it should be a file"));
     }
+
+    diagnostic_path = path;
 }
 
 void BackgroundClient::set_diagnostic_delay(int delay)


### PR DESCRIPTION
Fixes #93 by using `boost::filesystem::canonical()` to convert all inputted paths to absolute paths and deal with most error cases.

It may be wise to reconsider this PR and instead add path checking into `miral::ConfigurationOption`. If/when a client wants to use their own font for the diagnostic screen, we'll be back to doing all this checking internally within Frame when this can all be handled within Miral. I'll propose a PR for the Miral addition today.