### PR TITLE
[Merged by Bors] - Convert all `--diagnostic-path` paths to absolute

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -195,10 +195,10 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
             "Parent of diagnostic path is not a directory." + formatted_path_error));
     }
 
-    if (is_directory(path))
+    if (!is_regular_file(path) && exists(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Target of diagnostic path is a directory when it should be a file." + formatted_path_error));
+            "Target of diagnostic path is not a file." + formatted_path_error));
     }
 
     diagnostic_path = path;

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -195,6 +195,12 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
             "Parent of diagnostic path is not a directory." + formatted_path_error));
     }
 
+    if (!exists(path.parent_path()))
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Parent of diagnostic path does not exist." + formatted_path_error));
+    }
+
     diagnostic_path = path;
 }
 

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -189,13 +189,13 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
             "Parent of diagnostic path does not exist." + formatted_path_error));
     }
 
-    if (boost::filesystem::is_regular_file(path.parent_path()))
+    if (is_regular_file(path.parent_path()))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Parent of diagnostic path is not a directory." + formatted_path_error));
     }
 
-    if (!boost::filesystem::is_regular_file(path))
+    if (!is_regular_file(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Target of diagnostic path is a directory when it should be a file." + formatted_path_error));

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -183,22 +183,22 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         formatted_path_error.append("\n Resolved path: " + path.string());
     }
 
-    if (!boost::filesystem::is_regular_file(path))
+    if (!exists(path.parent_path()))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Target of diagnostic path is a directory when it should be a file." + formatted_path_error));
+            "Parent of diagnostic path does not exist." + formatted_path_error));
     }
-    
+
     if (boost::filesystem::is_regular_file(path.parent_path()))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Parent of diagnostic path is not a directory." + formatted_path_error));
     }
 
-    if (!exists(path.parent_path()))
+    if (!boost::filesystem::is_regular_file(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Parent of diagnostic path does not exist." + formatted_path_error));
+            "Target of diagnostic path is a directory when it should be a file." + formatted_path_error));
     }
 
     diagnostic_path = path;

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -175,16 +175,20 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         return;
     }
     
-    auto option_path = Path(option);
-    if (exists(option_path.parent_path()))
-    {
-        diagnostic_path = option_path;
-    }
-    else
+    auto const path = boost::filesystem::absolute(option);
+    if (boost::filesystem::is_directory(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Diagnostic path (" + option_path.parent_path().string() + ") does not exist"));
+            "Target of diagnostic path (" + path.string() + ") is a directory when it should be a file"));
     }
+    
+    if (boost::filesystem::is_regular_file(path.parent_path()))
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "Parent of diagnostic path (" + path.parent_path().string() + ") is not a directory"));
+    }
+
+    diagnostic_path = path;
 }
 
 void BackgroundClient::set_diagnostic_delay(int delay)

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -183,7 +183,7 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
         formatted_path_error.append("\n Resolved path: " + path.string());
     }
 
-    if (boost::filesystem::is_directory(path))
+    if (!boost::filesystem::is_regular_file(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Target of diagnostic path is a directory when it should be a file." + formatted_path_error));

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -189,13 +189,13 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
             "Parent of diagnostic path does not exist." + formatted_path_error));
     }
 
-    if (is_regular_file(path.parent_path()))
+    if (!is_directory(path.parent_path()))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Parent of diagnostic path is not a directory." + formatted_path_error));
     }
 
-    if (!is_regular_file(path))
+    if (is_directory(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "Target of diagnostic path is a directory when it should be a file." + formatted_path_error));

--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -176,16 +176,23 @@ void BackgroundClient::set_diagnostic_path(std::string const& option)
     }
     
     auto const path = boost::filesystem::absolute(option);
+
+    auto formatted_path_error = "\n Inputted path: " + option;
+    if (path.string() != option)
+    {
+        formatted_path_error.append("\n Resolved path: " + path.string());
+    }
+
     if (boost::filesystem::is_directory(path))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Target of diagnostic path (" + path.string() + ") is a directory when it should be a file"));
+            "Target of diagnostic path is a directory when it should be a file." + formatted_path_error));
     }
     
     if (boost::filesystem::is_regular_file(path.parent_path()))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error(
-            "Parent of diagnostic path (" + path.parent_path().string() + ") is not a directory"));
+            "Parent of diagnostic path is not a directory." + formatted_path_error));
     }
 
     diagnostic_path = path;


### PR DESCRIPTION
Fixes #93 by using `boost::filesystem::absolute()` to convert all inputted paths to absolute paths. Also deals with the error case where a user attempts to input a file as the parent directory.