### PR TITLE
Drop unnecessary content attribute

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,8 +85,7 @@ plugs:
 slots:
   ubuntu-frame-diagnostic:
     interface: content
-    content: writable-data
-    write: 
+    write:
       - $SNAP_COMMON/diagnostic
 
 parts:


### PR DESCRIPTION
Specifying this attribute is unnecessary (it defaults) and leads to discussion:

https://forum.snapcraft.io/t/global-autoconnect-request-for-ubuntu-frame-ubuntu-frame-diagnostic/32539/5

Let's just accept the default