### PR TITLE
[Merged by Bors] - Pick up display configuration when run as a user command

### DIFF
--- a/scripts/bin/run-user
+++ b/scripts/bin/run-user
@@ -5,6 +5,9 @@ if [ "$1" = "--help" ]; then set +x; fi
 
 mkdir -p "$HOME/.config/"
 # Copy the daemon config, dropping configuration keys that are specific to daemon execution
-grep -vE "(^vt=|^console-provider=vt|^display-layout=)" "$SNAP_DATA/frame.config" > "$HOME/.config/frame.config"
+grep -vE "(^vt=|^console-provider=vt)" "$SNAP_DATA/frame.config" > "$HOME/.config/frame.config"
+
+rm -f "$HOME/.config/frame.display"
+cp "$SNAP_DATA/frame.display" "$HOME/.config/" || true
 
 exec "$@"


### PR DESCRIPTION
We still won't use the configuration when hosted on X11, but this was causing confusion as:

    sudo ubuntu-frame

behaved differently to

    snap set ubuntu-frame daemon=true