### PR TITLE
[Merged by Bors] - Allow configuration to assign applications to outputs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(frame
     frame_window_manager.cpp frame_window_manager.h
     egfullscreenclient.cpp egfullscreenclient.h
     background_client.cpp background_client.h
+    snap_name_of.cpp snap_name_of.h
 )
 
 # Check for boost

--- a/src/frame_authorization.cpp
+++ b/src/frame_authorization.cpp
@@ -18,10 +18,7 @@
 
 #include "frame_authorization.h"
 
-#include <mir/log.h>
-#include <sys/apparmor.h>
-#include <cstring>
-#include <fstream>
+#include "snap_name_of.h"
 
 using namespace miral;
 
@@ -44,70 +41,6 @@ AuthModel const auth_model{{
 namespace
 {
 bool authorise_without_apparmor = false;
-
-auto snap_name_of(miral::Application const& app) -> std::string
-{
-    int const app_fd = miral::socket_fd_of(app);
-    char* label_cstr;
-    char* mode_cstr;
-    errno = 0;
-    if (app_fd < 0)
-    {
-        return "";
-    }
-    else if (aa_getpeercon(app_fd, &label_cstr, &mode_cstr) < 0)
-    {
-        mir::log_info("aa_getpeercon() failed for process %d: %s", miral::pid_of(app), strerror(errno));
-
-        if ((errno == EINVAL) && authorise_without_apparmor) // EINVAL is what is returned when AppArmor isn't setup
-        {
-            mir::log_info("Fall back (without AppArmor): Identify client via /proc/%%d/cmdline");
-
-            // using the id, find the name of this process
-            if (std::ifstream cmdline{"/proc/" + std::to_string(miral::pid_of(app)) + "/cmdline"})
-            {
-                std::string const path{std::istreambuf_iterator{cmdline}, std::istreambuf_iterator<char>{}};
-                std::string const snap_prefix{"/snap/"};
-
-                if (path.starts_with(snap_prefix))
-                {
-                    // Strip the prefix (after_snap_prefix) and app name (before_app_suffix) from the path
-                    auto const after_snap_prefix = begin(path) + snap_prefix.size();
-                    auto const before_app_suffix = std::find(after_snap_prefix, end(path), '/');
-
-                    // We also need to discard any parallel-install suffix (which starts with an underscore)
-                    auto const install_suffix = std::find(after_snap_prefix, before_app_suffix, '_');
-
-                    return std::string{after_snap_prefix, install_suffix};
-                }
-            }
-        }
-        return "";
-    }
-    else
-    {
-        std::string const label{label_cstr};
-        free(label_cstr);
-        // mode_cstr should NOT be freed, as it's from the same buffer as label_cstr
-
-        std::string const snap_prefix{"snap."};
-        if (label.starts_with(snap_prefix))
-        {
-            // Strip the prefix (after_snap_prefix) and app name (before_app_suffix) from the label
-            auto const after_snap_prefix = begin(label) + snap_prefix.size();
-            auto const before_app_suffix = std::find(after_snap_prefix, end(label), '.');
-
-            // We also need to discard any parallel-install suffix (which starts with an underscore)
-            auto const install_suffix = std::find(after_snap_prefix, before_app_suffix, '_');
-
-            return std::string{after_snap_prefix, install_suffix};
-        }
-        else
-        {
-            return "";
-        }
-    }
-}
 }
 
 AuthModel::AuthModel(
@@ -140,7 +73,7 @@ void init_authorization(miral::WaylandExtensions& extensions, AuthModel const& m
                 {
                     return info.user_preference().value();
                 }
-                auto const snap_name = snap_name_of(info.app());
+                auto const snap_name = snap_name_of(info.app(), authorise_without_apparmor);
                 return snaps.find(snap_name) != snaps.end();
             });
     }

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char const* argv[])
     DisplayConfiguration display_config{runner};
 #if MIRAL_VERSION >= MIR_VERSION_NUMBER(3, 8, 0)
     display_config.add_output_attribute(FrameWindowManagerPolicy::surface_title);
+    display_config.add_output_attribute(FrameWindowManagerPolicy::snap_name);
 #endif
     WaylandExtensions wayland_extensions;
     init_authorization(wayland_extensions, auth_model);

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -26,6 +26,7 @@
 #include <miral/keymap.h>
 #include <miral/runner.h>
 #include <miral/set_window_management_policy.h>
+#include <miral/version.h>
 #include <miral/wayland_extensions.h>
 
 int main(int argc, char const* argv[])
@@ -35,6 +36,9 @@ int main(int argc, char const* argv[])
     WindowManagerObserver window_manager_observer{};
 
     DisplayConfiguration display_config{runner};
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(3, 8, 0)
+    display_config.add_output_attribute(FrameWindowManagerPolicy::surface_title);
+#endif
     WaylandExtensions wayland_extensions;
     init_authorization(wayland_extensions, auth_model);
 

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -449,6 +449,7 @@ void FrameWindowManagerPolicy::PlacementMapping::set_output_for_surface(
         if (t2o.first == title)
         {
             specification.output_id() = t2o.second;
+            break;
         }
     }
 }
@@ -462,6 +463,7 @@ void FrameWindowManagerPolicy::PlacementMapping::set_output_for_snap(
         if (s2o.first == name)
         {
             specification.output_id() = s2o.second;
+            break;
         }
     }
 }

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -202,12 +202,6 @@ void FrameWindowManagerPolicy::assign_to_output(
 {
     placement_mapping.set_output_for_surface(specification, title);
     placement_mapping.set_output_for_snap(specification, snap_name);
-
-    if (!specification.output_id().is_set() && outputs.size() > 0)
-    {
-        // Place new windows round-robin on all available outputs
-        specification.output_id() = outputs[window_count->currently_open() % outputs.size()];
-    }
 }
 
 void FrameWindowManagerPolicy::advise_delete_window(WindowInfo const& window_info)
@@ -334,7 +328,6 @@ void FrameWindowManagerPolicy::advise_application_zone_delete(Zone const& applic
 void FrameWindowManagerPolicy::advise_output_create(miral::Output const &output)
 {
     WindowManagementPolicy::advise_output_create(output);
-    outputs.emplace_back(output.id());
 
     placement_mapping.update(output);
     display_layout_has_changed = true;
@@ -343,7 +336,6 @@ void FrameWindowManagerPolicy::advise_output_create(miral::Output const &output)
 void FrameWindowManagerPolicy::advise_output_delete(miral::Output const& output)
 {
     WindowManagementPolicy::advise_output_delete(output);
-    outputs.erase(std::remove(outputs.begin(), outputs.end(), output.id()), outputs.end());
 
     placement_mapping.clear(output);
     display_layout_has_changed = true;

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -178,9 +178,17 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
 
             if (specification.name())
             {
-                mir::log_info("[snap \"%s\"] New surface with title=\"%s\"",
-                              snap_instance_name.c_str(),
-                              specification.name().value().c_str());
+                if (!snap_instance_name.empty())
+                {
+                    mir::log_info("New surface for snap=\"%s\" with title=\"%s\"",
+                                  snap_instance_name.c_str(),
+                                  specification.name().value().c_str());
+                }
+                else
+                {
+                    mir::log_info("New surface with title=\"%s\"",
+                                  specification.name().value().c_str());
+                }
             }
 
             assign_to_output(specification, specification.name(), snap_instance_name);
@@ -227,10 +235,21 @@ void FrameWindowManagerPolicy::handle_modify_window(WindowInfo& window_info, Win
 
         if (specification.name())
         {
-            mir::log_info("[snap \"%s\"] Surface retitled to \"%s\" (was `\"%s\")",
-                          snap_instance_name.c_str(),
-                          specification.name().value().c_str(),
-                          window_info.name().c_str());
+            if (!snap_instance_name.empty())
+            {
+                mir::log_info(
+                    "Surface for snap=\"%s\" retitled to \"%s\" (was \"%s\")",
+                    snap_instance_name.c_str(),
+                    specification.name().value().c_str(),
+                    window_info.name().c_str());
+            }
+            else
+            {
+                mir::log_info(
+                    "Surface retitled to \"%s\" (was \"%s\")",
+                    specification.name().value().c_str(),
+                    window_info.name().c_str());
+            }
         }
         assign_to_output(specification, window_info.name(), snap_instance_name);
 

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -178,9 +178,7 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
         if (override_state(specification, window_info))
         {
             assign_to_output(specification, specification.name(), snap_instance_name_of(app_info.application()));
-            specification.state() = mir_window_state_maximized;
-            tools.place_and_size_for_state(specification, window_info);
-            specification.state() = mir_window_state_fullscreen;
+            apply_bespoke_fullscreen_placement(specification, window_info);
         }
     }
 
@@ -221,12 +219,18 @@ void FrameWindowManagerPolicy::handle_modify_window(WindowInfo& window_info, Win
     {
         assign_to_output(specification, window_info.name(), snap_instance_name_of(window_info.window().application()));
 
-        specification.state() = mir_window_state_maximized;
-        tools.place_and_size_for_state(specification, window_info);
-        specification.state() = mir_window_state_fullscreen;
+        apply_bespoke_fullscreen_placement(specification, window_info);
     }
 
     MinimalWindowManager::handle_modify_window(window_info, specification);
+}
+
+void FrameWindowManagerPolicy::apply_bespoke_fullscreen_placement(
+    WindowSpecification& specification, WindowInfo const& window_info) const
+{
+    specification.state() = mir_window_state_maximized;
+    tools.place_and_size_for_state(specification, window_info);
+    specification.state() = mir_window_state_fullscreen;
 }
 
 auto FrameWindowManagerPolicy::confirm_placement_on_display(
@@ -270,9 +274,7 @@ void FrameWindowManagerPolicy::advise_end()
                        if (override_state(specification, info))
                        {
                            assign_to_output(specification, info.name(), snap_instance_name_of(info.window().application()));
-                           specification.state() = mir_window_state_maximized;
-                           tools.place_and_size_for_state(specification, info);
-                           specification.state() = mir_window_state_fullscreen;
+                           apply_bespoke_fullscreen_placement(specification, info);
                            tools.modify_window(info, specification);
                        }
                    }

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -18,6 +18,7 @@
 
 #include "snap_name_of.h"
 
+#include <mir/log.h>
 #include <miral/application_info.h>
 #include <miral/output.h>
 #include <miral/toolkit_event.h>
@@ -177,7 +178,16 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
         WindowInfo window_info{};
         if (override_state(specification, window_info))
         {
-            assign_to_output(specification, specification.name(), snap_instance_name_of(app_info.application()));
+            auto const snap_instance_name = snap_instance_name_of(app_info.application());
+
+            if (specification.name())
+            {
+                mir::log_info("[snap \"%s\"] New surface with title=\"%s\"",
+                              snap_instance_name.c_str(),
+                              specification.name().value().c_str());
+            }
+
+            assign_to_output(specification, specification.name(), snap_instance_name);
             apply_bespoke_fullscreen_placement(specification, window_info);
         }
     }
@@ -217,7 +227,16 @@ void FrameWindowManagerPolicy::handle_modify_window(WindowInfo& window_info, Win
 
     if (override_state(specification, window_info))
     {
-        assign_to_output(specification, window_info.name(), snap_instance_name_of(window_info.window().application()));
+        auto const snap_instance_name = snap_instance_name_of(window_info.window().application());
+
+        if (specification.name())
+        {
+            mir::log_info("[snap \"%s\"] Surface retitled to \"%s\" (was `\"%s\")",
+                          snap_instance_name.c_str(),
+                          specification.name().value().c_str(),
+                          window_info.name().c_str());
+        }
+        assign_to_output(specification, window_info.name(), snap_instance_name);
 
         apply_bespoke_fullscreen_placement(specification, window_info);
     }

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -108,7 +108,6 @@ private:
 
     bool application_zones_have_changed = false;
     bool display_layout_has_changed = false;
-    std::vector<int> outputs = {};
 
     class PlacementMapping
     {

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2022 Canonical Ltd.
+ * Copyright © Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 or 3 as
@@ -12,8 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored By: Alan Griffiths <alan@octopull.co.uk>
  */
 
 #ifndef FRAME_WINDOW_MANAGER_H
@@ -75,6 +73,8 @@ class FrameWindowManagerPolicy : public miral::MinimalWindowManager
 public:
     using miral::MinimalWindowManager::MinimalWindowManager;
 
+    static std::string const surface_title;
+
     FrameWindowManagerPolicy(miral::WindowManagerTools const& tools, WindowManagerObserver& window_manager_observer);
 
     auto place_new_window(miral::ApplicationInfo const& app_info, miral::WindowSpecification const& request)
@@ -98,12 +98,18 @@ public:
     void advise_output_create(miral::Output const &output) override;
     void advise_output_delete(miral::Output const &output) override;
 
+    void advise_output_update(miral::Output const& updated, miral::Output const& original) override;
+
 private:
     WindowManagerObserver const& window_manager_observer;
     std::shared_ptr<WindowCount> window_count = std::make_shared<WindowCount>();
 
     bool application_zones_have_changed = false;
     std::vector<int> outputs = {};
+    std::vector<std::pair<std::string, int>> app_name_to_output_id;
+
+    void assign_to_output(
+        miral::WindowSpecification& specification, mir::optional_value<std::string> const& title);
 };
 
 #endif /* FRAME_WINDOW_MANAGER_H */

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -126,6 +126,10 @@ private:
     void assign_to_output(
         miral::WindowSpecification& specification, mir::optional_value<std::string> const& title,
         std::string_view snap_name);
+
+    void apply_bespoke_fullscreen_placement(
+        miral::WindowSpecification& specification,
+        miral::WindowInfo const& window_info) const;
 };
 
 #endif /* FRAME_WINDOW_MANAGER_H */

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -107,6 +107,7 @@ private:
     std::shared_ptr<WindowCount> window_count = std::make_shared<WindowCount>();
 
     bool application_zones_have_changed = false;
+    bool display_layout_has_changed = false;
     std::vector<int> outputs = {};
 
     class PlacementMapping

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <vector>
+#include <optional>
 
 using namespace mir::geometry;
 
@@ -74,6 +75,7 @@ public:
     using miral::MinimalWindowManager::MinimalWindowManager;
 
     static std::string const surface_title;
+    static std::string const snap_name;
 
     FrameWindowManagerPolicy(miral::WindowManagerTools const& tools, WindowManagerObserver& window_manager_observer);
 
@@ -106,10 +108,24 @@ private:
 
     bool application_zones_have_changed = false;
     std::vector<int> outputs = {};
-    std::vector<std::pair<std::string, int>> app_name_to_output_id;
+
+    class PlacementMapping
+    {
+    public:
+        void update(miral::Output const& output);
+        void clear(miral::Output const& output);
+
+        void set_output_for_surface(miral::WindowSpecification& specification, mir::optional_value<std::string> const& title) const;
+        void set_output_for_snap(miral::WindowSpecification& specification, std::string_view name) const;
+
+    private:
+        std::vector<std::pair<std::string, int>> surface_title_to_output_id;
+        std::vector<std::pair<std::string, int>> snap_name_to_output_id;
+    } placement_mapping;
 
     void assign_to_output(
-        miral::WindowSpecification& specification, mir::optional_value<std::string> const& title);
+        miral::WindowSpecification& specification, mir::optional_value<std::string> const& title,
+        std::string_view snap_name);
 };
 
 #endif /* FRAME_WINDOW_MANAGER_H */

--- a/src/snap_name_of.cpp
+++ b/src/snap_name_of.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "snap_name_of.h"
+
+#include <mir/log.h>
+#include <sys/apparmor.h>
+
+#include <cstring>
+#include <fstream>
+
+namespace
+{
+
+}
+auto snap_name_of(miral::Application const& app, bool fallback_without_apparmor, bool strip_parellel) -> std::string
+{
+    int const app_fd = miral::socket_fd_of(app);
+    char* label_cstr;
+    char* mode_cstr;
+    errno = 0;
+    if (app_fd < 0)
+    {
+        return "";
+    }
+    else if (aa_getpeercon(app_fd, &label_cstr, &mode_cstr) < 0)
+    {
+        mir::log_info("aa_getpeercon() failed for process %d: %s", miral::pid_of(app), strerror(errno));
+
+        if ((errno == EINVAL) && fallback_without_apparmor) // EINVAL is what is returned when AppArmor isn't setup
+        {
+            mir::log_info("Fall back (without AppArmor): Identify client via /proc/%%d/cmdline");
+
+            // using the id, find the name of this process
+            if (std::ifstream cmdline{"/proc/" + std::to_string(miral::pid_of(app)) + "/cmdline"})
+            {
+                std::string const path{std::istreambuf_iterator{cmdline}, std::istreambuf_iterator<char>{}};
+                std::string const snap_prefix{"/snap/"};
+
+                if (path.starts_with(snap_prefix))
+                {
+                    // Strip the prefix (after_snap_prefix) and app name (before_app_suffix) from the path
+                    auto const after_snap_prefix = begin(path) + snap_prefix.size();
+                    auto const before_app_suffix = std::find(after_snap_prefix, end(path), '/');
+
+                    // We also need to discard any parallel-install suffix (which starts with an underscore)
+                    if (strip_parellel)
+                    {
+                        auto const install_suffix = std::find(after_snap_prefix, before_app_suffix, '_');
+                        return std::string{after_snap_prefix, install_suffix};
+                    }
+                    else
+                    {
+                        return std::string{after_snap_prefix, before_app_suffix};
+                    }
+                }
+            }
+        }
+        return "";
+    }
+    else
+    {
+        std::string const label{label_cstr};
+        free(label_cstr);
+        // mode_cstr should NOT be freed, as it's from the same buffer as label_cstr
+
+        std::string const snap_prefix{"snap."};
+        if (label.starts_with(snap_prefix))
+        {
+            // Strip the prefix (after_snap_prefix) and app name (before_app_suffix) from the label
+            auto const after_snap_prefix = begin(label) + snap_prefix.size();
+            auto const before_app_suffix = std::find(after_snap_prefix, end(label), '.');
+
+            // We also need to discard any parallel-install suffix (which starts with an underscore)
+            auto const install_suffix = std::find(after_snap_prefix, before_app_suffix, '_');
+
+            // We also need to discard any parallel-install suffix (which starts with an underscore)
+            if (strip_parellel)
+            {
+                return std::string{after_snap_prefix, install_suffix};
+            }
+            else
+            {
+                return std::string{after_snap_prefix, before_app_suffix};
+            }
+        }
+        else
+        {
+            return "";
+        }
+    }
+}
+
+auto snap_name_of(miral::Application const& app, bool fallback_without_apparmor) -> std::string
+{
+    return snap_name_of(app, fallback_without_apparmor, true);
+}
+
+auto snap_instance_name_of(miral::Application const& app) -> std::string
+{
+    return snap_name_of(app, true, false);
+}

--- a/src/snap_name_of.h
+++ b/src/snap_name_of.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FRAME_SNAP_NAME_OF_H
+#define FRAME_SNAP_NAME_OF_H
+
+#include <miral/application.h>
+
+#include <string>
+
+auto snap_name_of(miral::Application const& app, bool fallback_without_apparmor) -> std::string;
+auto snap_instance_name_of(miral::Application const& app) -> std::string;
+
+#endif // FRAME_SNAP_NAME_OF_H


### PR DESCRIPTION
Uses https://github.com/MirServer/mir/pull/2853 to associate surface titles with outputs and move those apps to those outputs

WIP as:

1. it won't build on edge without the Mir PR landing; and,
2. there's more to be done to support other ways to map apps to outputs