### PR TITLE
Draw the background/diagnostic on the worker thread

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -24,7 +24,6 @@
 #include <cstring>
 #include <codecvt>
 #include <sstream>
-#include <thread>
 
 #include <boost/throw_exception.hpp>
 #include <boost/filesystem.hpp>

--- a/src/egfullscreenclient.h
+++ b/src/egfullscreenclient.h
@@ -213,7 +213,7 @@ private:
 
     void draw();
 
-    mir::Fd const flush_signal;
+    mir::Fd const draw_signal;
     mir::Fd const shutdown_signal;
     mir::Fd const diagnostic_signal;
 


### PR DESCRIPTION
We've been mostly getting away with drawing and flushing on random threads because these windows are rarely updated and we get consistency by dumb luck.

But if the timing is "just right" (see #151) all hell breaks loose.

Clearly there was a time when we thought about which calls need to be on the worker thread, because there was a semaphore to cause a flush, but that wasn't being used by the current code. (Logically, it should have been used in `FullscreenClient::draw()` as that doesn't run on the worker thread, but that doesn't actually fix #151 because `wl_surface_attach()` fails.)

Anyway, as we're not using `flush_signal`, and `draw_screen()` needs to be called on the worker thread, and the only place that isn't true is `draw()`, we can replace it with a `draw_signal` and do everything right.

Fixes: #151