### PR TITLE
Drop some deprecated and/or obsolete stuff (and fix edge)

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -22,7 +22,6 @@ EOT
     mv "${display_file}"  "${display_file}.save" || true
     mv "${display_temp}" "${display_file}"
     chmod a+r "${display_file}"
-    ! [ -e "${SNAP}/miral-lt-3.8" ] || ((config_changes+=1))
   else
     rm "${display_temp}"
   fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,10 +113,16 @@ parts:
       - libapparmor-dev
       - libfreetype6-dev
     stage-packages:
-      - libmiral6
       - libboost-filesystem1.74.0
       - libboost-iostreams1.74.0
-  
+      # Stage libmiral<n> indirectly as we cannot (since core22) do `try:/else:`
+      - libmiral-dev
+    prime:
+      # Do not prime the `-dev` part of libmiral-dev, we don't need it (just the libmiral<n> dependency)
+      - -usr/include
+      - -usr/lib/*/pkgconfig
+      - -usr/lib/*/libmir*.so
+
   assets:
     plugin: nil
     stage-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,7 +18,7 @@ architectures:
 
 environment:
   # Prep for Mir
-  MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform
+  MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/mir/server-platform
   LIBINPUT_QUIRKS_DIR: ${SNAP}/usr/share/libinput
   # Setup XKB
   XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
@@ -131,7 +131,7 @@ parts:
       - mir-platform-graphics-x
       - mir-platform-graphics-eglstream-kms
     prime:
-      - usr/lib/${CRAFT_ARCH_TRIPLET}
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}
       - usr/share/libinput
 
   icons:
@@ -173,9 +173,9 @@ parts:
       miral_version=`LANG=C apt-cache policy libmiral-dev | sed -rne 's/^\s+Candidate:\s+([0-9]*\.[0-9])\..+$/\1/p'`
       if [ ${miral_version%.*} -eq 3 ] && [ ${miral_version#*.} -lt 8 ]
       then
-        touch $SNAPCRAFT_PRIME/miral-lt-3.8
+        touch ${CRAFT_PRIME}/miral-lt-3.8
       else
-        rm -f $SNAPCRAFT_PRIME/miral-lt-3.8
+        rm -f ${CRAFT_PRIME}/miral-lt-3.8
       fi
     prime:
       - bin/graphics-core22-wrapper

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -169,13 +169,5 @@ parts:
       ${CRAFT_PART_SRC}/bin/graphics-core22-cleanup mesa-core22
       rm -rf ${CRAFT_PRIME}/usr/{doc,man,lintian,pkgconfig,X11}
 
-      # Back compatibility fix until MirAL 3.8 is released
-      miral_version=`LANG=C apt-cache policy libmiral-dev | sed -rne 's/^\s+Candidate:\s+([0-9]*\.[0-9])\..+$/\1/p'`
-      if [ ${miral_version%.*} -eq 3 ] && [ ${miral_version#*.} -lt 8 ]
-      then
-        touch ${CRAFT_PRIME}/miral-lt-3.8
-      else
-        rm -f ${CRAFT_PRIME}/miral-lt-3.8
-      fi
     prime:
       - bin/graphics-core22-wrapper


### PR DESCRIPTION
Also fixed the `edge` builds, by staging `libmiral{6,7}` indirectly. (The old trick of `try: [libmiral7]/else: [libmiral6]` is no longer supported by snapcraft 