### PR TITLE
(#262) only relayout a window if the client requests for its state, position, or size to change

### DIFF
--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -297,6 +297,7 @@ void FrameWindowManagerPolicy::handle_modify_window(WindowInfo& window_info, Win
 {
     WindowSpecification specification = modifications;
 
+    // FIXME: this shouldn't be necessary, see canonical/mir#4282
     // If the client requests a change to its state, size, or topleft, we for a
     // relayout so that it is aware of its true parameters.
     if (specification.state().is_set() || specification.size().is_set() || specification.top_left().is_set())


### PR DESCRIPTION
fixes canonical/mir#4282 

## What's new?
We were applying the layout to a the window on every surface modification, which isn't right. Instead, it makes sense to apply it whenever the client attempts to change the state, size, or position of the surface. That way, we force the surface into the right position again.