### PR TITLE
doc: use refs to Mir's `latest` documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,6 +297,7 @@ intersphinx_mapping = {
         None,
     ),
     "mir": ("https://canonical-mir.readthedocs-hosted.com/stable", None),
+    "mir-latest": ("https://canonical-mir.readthedocs-hosted.com/latest", None),
     "core": ("https://documentation.ubuntu.com/core", None),
     "server": ("https://documentation.ubuntu.com/server", None),
     "snapcraft": ("https://documentation.ubuntu.com/snapcraft/stable", None),

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -6,8 +6,9 @@ The explanatory and conceptual guides in this section provide a better understan
 Start with the [Ubuntu Frame Datasheet](https://assets.ubuntu.com/v1/713b9224-Ubuntu.Frame.Datasheet.pdf) which gives a high level overview of Ubuntu Frame.
 
 More detail is provided in:
+
 - {ref}`where-does-ubuntu-frame-work`.
-- {doc}`mir:explanation/mir-graphics-support`
+- {ref}`mir-latest:exp-mir-graphics-support`
 - {ref}`security`.
 
 ```{toctree}

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -8,7 +8,7 @@ ______________________________________________________________________
 
 ## Threat model
 
-We ran threat modeling for Mir itself (the [display server library](https://mir-server.io/) underpinning Frame) based on this snap stack, and maintain that documented there: {doc}`Mir Security documentation <mir:explanation/security>`.
+We ran threat modeling for Mir itself (the [display server library](https://mir-server.io/) underpinning Frame) based on this snap stack, and maintain that documented there: {ref}`Mir Security documentation <mir-latest:exp-security>`.
 
 ## Cryptography
 

--- a/docs/explanation/where-does-ubuntu-frame-work.md
+++ b/docs/explanation/where-does-ubuntu-frame-work.md
@@ -12,7 +12,7 @@ We recommend Ubuntu Core for a lot of purposes, but you should be able to use Ub
 
 ## Suitable graphics
 
-Ubuntu Frame is based on Mir which {doc}`supports a range of graphics options <mir:explanation/mir-graphics-support>`. The current iteration of Ubuntu Frame does not support all of these, just "gbm-kms".
+Ubuntu Frame is based on Mir which {ref}`supports a range of graphics options <mir-latest:exp-mir-graphics-support>`. The current iteration of Ubuntu Frame does not support all of these, just "gbm-kms".
 
 In general, this means that Ubuntu Frame can work with any driver providing KMS, `libgbm` and an EGL supporting [EGL_WL_bind_wayland_display ](https://registry.khronos.org/EGL/extensions/WL/EGL_WL_bind_wayland_display.txt).
 

--- a/docs/how-to/use-snap-graphics-on-base-core20.md
+++ b/docs/how-to/use-snap-graphics-on-base-core20.md
@@ -12,7 +12,7 @@ Until recently, we have been including the mesa drivers inside the snap as these
 - Security updates to mesa require all the server and client snaps to be rebuilt and distributed; and
 - There's no way to introduce other drivers, even if Mir supports them.
 
-This led to some frustration as there are a number of {doc}`graphics stacks that Mir supports <mir:explanation/mir-graphics-support>` that were not [supported by mir-kiosk](https://discourse.ubuntu.com/t/where-does-mir-kiosk-work/22270). With [Ubuntu Frame](https://snapcraft.io/ubuntu-frame) we have adopted a more flexible approach.
+This led to some frustration as there are a number of {ref}`graphics stacks that Mir supports <mir-latest:exp-mir-graphics-support>` that were not [supported by mir-kiosk](https://discourse.ubuntu.com/t/where-does-mir-kiosk-work/22270). With [Ubuntu Frame](https://snapcraft.io/ubuntu-frame) we have adopted a more flexible approach.
 
 ### Introducing graphics-core20
 


### PR DESCRIPTION
Using `latest` will allow us to follow Mir's docs more closely.