### PR TITLE
ci: fix tics dependencies

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -38,7 +38,9 @@ jobs:
           gcovr \
           lcov \
           libapparmor-dev \
+          libboost-filesystem-dev \
           libboost-iostreams-dev \
+          libboost-system-dev \
           libgtest-dev \
           libgmock-dev \
           libfreetype6-dev \


### PR DESCRIPTION
These no longer come with Mir.