### PR TITLE
Fix variable mismatch in configure output

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -121,7 +121,7 @@ if [ "$(snapctl get launcher)" = "true" ]; then
 
   if ! snapctl is-connected desktop-launch; then
     echo "Please connect the "desktop-launch" interface:"
-    echo "  sudo snap connect $SNAP_INTERFACE_NAME:desktop-launch"
+    echo "  sudo snap connect $SNAP_INSTANCE_NAME:desktop-launch"
     exit 2
   fi
 


### PR DESCRIPTION
Just noticed the following output:

```
> sudo snap set ubuntu-frame launcher=true
error: cannot perform the following tasks:
- Run configure hook of "ubuntu-frame" snap (run hook "configure": 
-----
Please connect the desktop-launch interface:
/snap/ubuntu-frame/17876/meta/hooks/configure: line 124: SNAP_INTERFACE_NAME: unbound variable
-----)
```

Thanks!