### PR TITLE
Add mini accessibility launcher

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -394,6 +394,7 @@ intersphinx_mapping = {
     "frame-22": ("https://ubuntu.com/frame/docs/22", None),
     "server": ("https://ubuntu.com/server/docs", None),
     "snapcraft": ("https://documentation.ubuntu.com/snapcraft/stable", None),
+    "snap": ("https://snapcraft.io/docs/", None),
     "subiquity": (
         "https://canonical-subiquity.readthedocs-hosted.com/en/latest",
         None,

--- a/docs/reference/configuring-ubuntu-frame-through-a-gadget-snap.md
+++ b/docs/reference/configuring-ubuntu-frame-through-a-gadget-snap.md
@@ -1,14 +1,14 @@
 ---
 myst:
   html_meta:
-    description: Ubuntu Frame gadget snap reference shows how to set default Frame configuration in gadget snaps, including display layouts, wallpaper, Wayland extensions, and daemon state.
+    description: Ubuntu Frame gadget snap reference shows how to set default Frame configuration in gadget snaps, including display layouts, wallpaper, Wayland extensions, launcher options, and daemon state.
 ---
 
 (configuring-ubuntu-frame-through-a-gadget-snap)=
 
 # Configuring Ubuntu Frame through a gadget snap
 
-The [snapcraft documentation](https://snapcraft.io/docs/the-gadget-snap) describes gadget snaps in detail. The only additional thing we'll show here is an example showing how to set the above configuration options for `ubuntu-frame`:
+The {ref}`snapcraft documentation <snap:reference-development-yaml-schemas-the-gadget-snap>` describes gadget snaps in detail. The only additional thing we'll show here is an example showing how to set the configuration options of `ubuntu-frame`:
 
 ```yaml
 defaults:
@@ -25,4 +25,8 @@ defaults:
       wallpaper-bottom=0xdd4814
       add-wayland-extensions=zwp_pointer_constraints_v1:zwp_relative_pointer_manager_v1
     daemon: true
+    launcher:
+      tail: magnifier,cursor-scale,output-filter
 ```
+
+See {ref}`ubuntu-frame-configuration-options` for the reference on available options.

--- a/docs/reference/ubuntu-frame-configuration-options.md
+++ b/docs/reference/ubuntu-frame-configuration-options.md
@@ -19,7 +19,11 @@ ______________________________________________________________________
 There are four snap configuration options:
 
 - `daemon=[true|false]` enables the daemon (defaults to true on Ubuntu Core and false on classic systems)
-- `launcher=[true|false]` enables a side bar application switcher if your solution calls for that
+- `launcher=[true|false|<object>]` enables a side bar application switcher if your solution calls for that;
+  if set to an object, the following will add one or more accessibility options at the bottom of it:
+  ```json
+  { "tail": ["magnifier", "cursor-scale", "output-filter"] }
+  ```
 - `config=<contents for frame.config>`
 - `display=<contents for frame.display>`
 
@@ -68,6 +72,23 @@ Make sure that the applications you want to run are annotated with metadata and 
 
 ```{tip}
 Since version **211**, you can use `Mir` or `UbuntuFrame` in [`OnlyShowIn=` and `NotShowIn=`](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html) to control visibility of the icon on different environments. This is useful to hide the daemon app in snaps that are also useful outside of the Frame ecosystem.
+```
+
+The launcher also supports an accessibility panel at the bottom. To enable it, pass a JSON object with a `tail` array containing any combination of `magnifier`, `cursor-scale`, and `output-filter`:
+
+```bash
+# Show only the magnifier and cursor scale options
+$ snap set ubuntu-frame launcher='{ "tail": [ "magnifier", "cursor-scale" ] }'
+```
+
+Once set to an object, you can also access / modify it via the `launcher.tail` key as a comma-separated list:
+
+```
+# Show all accessibility options
+$ snap set ubuntu-frame launcher.tail=magnifier,cursor-scale,output-filter
+
+# Disable the accessibility panel (empty tail)
+$ snap set ubuntu-frame launcher.tail=
 ```
 
 ### `config`

--- a/launcher/lib/controllers/accessibility_controller.dart
+++ b/launcher/lib/controllers/accessibility_controller.dart
@@ -24,7 +24,7 @@ import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
 class AccessibilityController {
   static const optionsEnvKey = 'UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_OPTIONS';
   static const _accessibilityConfigKey =
-      "UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH";
+      "UBUNTU_FRAME_ACCESSIBILITY_CONFIG_PATH";
   static final allOptions = [
     AccessibilityOption(
       id: 'magnifier',
@@ -122,7 +122,7 @@ class AccessibilityController {
   }
 
   /// The path at which the accessibility INI file is written. Reads the
-  /// [UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH] environment variable;
+  /// [UBUNTU_FRAME_ACCESSIBILITY_CONFIG_PATH] environment variable;
   /// returns an empty string (disabling file I/O) if the variable is not set.
   static String get _configPath =>
       Platform.environment[_accessibilityConfigKey] ?? '';

--- a/launcher/lib/controllers/accessibility_controller.dart
+++ b/launcher/lib/controllers/accessibility_controller.dart
@@ -81,47 +81,32 @@ class AccessibilityController {
             .info('Option "${option.id}" not found in config; keeping default');
         continue;
       }
-      final applied = option.setValueFromString(stored);
-      if (applied) {
-        _logger
-            .info('Option "${option.id}" initialised to "$stored" from config');
-      } else {
-        _logger.warning(
-            'Option "${option.id}" stored value "$stored" is not in the '
-            'allowed values list ${option.values}; keeping default');
-      }
+      option.setValueFromString(stored);
     }
   }
 
   void expand() {
-    _logger.info('Accessibility panel expanded');
     _isExpanded = true;
     _controller.add(true);
   }
 
   void collapse() {
-    _logger.info('Accessibility panel collapsed');
     _isExpanded = false;
     _controller.add(false);
   }
 
   void cycleForward(AccessibilityOption option) {
     option.cycleForward();
-    _logger.info(
-        'Option "${option.label}" cycled forward -> "${option.currentValue}"');
     _writeCurrentConfig();
   }
 
   void cycleBackward(AccessibilityOption option) {
     option.cycleBackward();
-    _logger.info(
-        'Option "${option.label}" cycled backward -> "${option.currentValue}"');
     _writeCurrentConfig();
   }
 
   Future<void> _writeCurrentConfig() async {
     if (_configPath.isEmpty) {
-      _logger.warning('ACCESSIBILITY_CONFIG_PATH is not set; skipping write');
       return;
     }
 
@@ -134,7 +119,6 @@ class AccessibilityController {
       final file = File(_configPath);
       await file.parent.create(recursive: true);
       await file.writeAsString(buffer.toString());
-      _logger.info('Wrote accessibility config to $_configPath');
     } catch (e) {
       _logger.shout('Failed to write accessibility config to $_configPath: $e');
     }

--- a/launcher/lib/controllers/accessibility_controller.dart
+++ b/launcher/lib/controllers/accessibility_controller.dart
@@ -1,0 +1,186 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:ini/ini.dart';
+import 'package:logging/logging.dart';
+import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
+
+class AccessibilityController {
+  static const optionsEnvKey = 'UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_OPTIONS';
+  static const _accessibilityConfigKey =
+      "UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH";
+  static final allOptions = [
+    AccessibilityOption(
+      id: 'magnifier',
+      configKey: 'magnifier_enable',
+      icon: Icons.zoom_in,
+      values: ['true', 'false'],
+    ),
+    AccessibilityOption(
+      id: 'output-filter',
+      configKey: 'output_filter',
+      icon: Icons.filter_b_and_w,
+      values: ['none', 'grayscale', 'invert'],
+    ),
+    AccessibilityOption(
+      id: 'cursor-scale',
+      configKey: 'cursor_scale',
+      icon: Icons.ads_click_outlined,
+      values: ['1', '1.5', '2'],
+    ),
+  ];
+
+  static final _logger = Logger('AccessibilityController');
+  final List<AccessibilityOption> options;
+
+  AccessibilityController._({required this.options});
+
+  static List<AccessibilityOption> _getActiveOptions() {
+    final optionsEnv = Platform.environment[optionsEnvKey];
+
+    // Not set, show all
+    if (optionsEnv == null) {
+      return allOptions;
+    }
+
+    // Set to be explicitly empty
+    if (optionsEnv.isEmpty) {
+      return [];
+    }
+
+    final activeOptions = <AccessibilityOption>[];
+    for (final id in optionsEnv.split(',')) {
+      final optionIndex = allOptions.indexWhere((o) => o.id == id);
+      if (optionIndex != -1) {
+        activeOptions.add(allOptions[optionIndex]);
+      } else {
+        _logger.warning('$optionsEnvKey: unknown option "$id", skipping');
+      }
+    }
+
+    return activeOptions;
+  }
+
+  static Future<List<AccessibilityOption>> _loadActiveOptionValues(
+      List<AccessibilityOption> activeOptions, String configPath) async {
+    if (configPath.isEmpty) {
+      _logger.warning(
+          '$_accessibilityConfigKey is not set; skipping startup read');
+      return activeOptions;
+    }
+
+    final file = File(configPath);
+    if (!await file.exists()) {
+      _logger.info('No accessibility config file found at $configPath; '
+          'all options will use their defaults');
+      return activeOptions;
+    }
+
+    final Map<String, String> storedValues = {};
+    try {
+      final contents = await file.readAsString();
+      final config = Config.fromString(contents);
+      // The ini parsing library we use puts everything not under a section into
+      // the 'default' section. It will always exist.
+      const section = 'default';
+      for (final key in config.options(section)!) {
+        storedValues[key] = config.get(section, key)!;
+      }
+    } catch (e, stackTrace) {
+      _logger.shout('Failed to read accessibility config from $configPath', e,
+          stackTrace);
+      return activeOptions;
+    }
+
+    for (final option in activeOptions) {
+      final stored = storedValues[option.configKey];
+      if (stored == null) {
+        _logger
+            .info('Option "${option.id}" not found in config; keeping default');
+        continue;
+      }
+      option.setValueFromString(stored);
+    }
+
+    return activeOptions;
+  }
+
+  /// The path at which the accessibility INI file is written. Reads the
+  /// [UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH] environment variable;
+  /// returns an empty string (disabling file I/O) if the variable is not set.
+  static String get _configPath =>
+      Platform.environment[_accessibilityConfigKey] ?? '';
+
+  /// Reads the accessibility config file on disk and sets each option's
+  /// current value. Options absent from the file, or with an unrecognised
+  /// value, are left at their default (index 0).
+  static Future<AccessibilityController> create() async {
+    final activeOptions = _loadActiveOptionValues(
+        AccessibilityController._getActiveOptions(), _configPath);
+    return AccessibilityController._(options: await activeOptions);
+  }
+
+  void cycleForward(AccessibilityOption option) {
+    option.cycleForward();
+    _enqueueWrite();
+  }
+
+  void cycleBackward(AccessibilityOption option) {
+    option.cycleBackward();
+    _enqueueWrite();
+  }
+
+  /// Pending write chain — each write is appended here so they are
+  /// executed strictly in order and never overlap.
+  Future<void> _writeFuture = Future.value();
+
+  /// Snapshot the current option values and append an atomic write to the
+  /// serial queue. Any number of rapid calls will be ordered correctly
+  /// because each write is chained onto the previous one.
+  void _enqueueWrite() {
+    // Capture the values *now*, before any await, so the write reflects
+    // the state at the moment this cycle happened.
+    final snapshot = {for (final opt in options) opt.configKey: opt.currentValue};
+    _writeFuture = _writeFuture.then((_) => _writeSnapshot(snapshot));
+  }
+
+  Future<void> _writeSnapshot(Map<String, String> snapshot) async {
+    if (_configPath.isEmpty) return;
+
+    final buffer = StringBuffer();
+    for (final entry in snapshot.entries) {
+      buffer.writeln('${entry.key} = ${entry.value}');
+    }
+
+    final target = File(_configPath);
+    final tmp = File('$_configPath.tmp');
+    try {
+      await target.parent.create(recursive: true);
+      await tmp.writeAsString(buffer.toString());
+      await tmp.rename(_configPath);
+    } catch (e, stackTrace) {
+      _logger.shout('Failed to write accessibility config to $_configPath', e,
+          stackTrace);
+      // Best-effort cleanup of the temp file.
+      try {
+        if (await tmp.exists()) await tmp.delete();
+      } catch (_) {}
+    }
+  }
+}

--- a/launcher/lib/controllers/accessibility_controller.dart
+++ b/launcher/lib/controllers/accessibility_controller.dart
@@ -38,9 +38,9 @@ class AccessibilityController {
   final _accessibilityConfigKey =
       "UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH";
 
-  /// The path at which the accessibility INI file is written.
-  /// Reads the [ACCESSIBILITY_CONFIG_PATH] environment variable; returns an
-  /// empty string (disabling file I/O) if the variable is not set.
+  /// The path at which the accessibility INI file is written. Reads the
+  /// [UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH] environment variable;
+  /// returns an empty string (disabling file I/O) if the variable is not set.
   String get _configPath => Platform.environment[_accessibilityConfigKey] ?? '';
 
   /// Reads the accessibility config file on disk and sets each option's

--- a/launcher/lib/controllers/accessibility_controller.dart
+++ b/launcher/lib/controllers/accessibility_controller.dart
@@ -1,0 +1,142 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:ini/ini.dart';
+import 'package:logging/logging.dart';
+import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
+
+class AccessibilityController {
+  final _logger = Logger('AccessibilityController');
+
+  bool _isExpanded = false;
+  bool get isExpanded => _isExpanded;
+
+  final List<AccessibilityOption> options;
+
+  final _controller = StreamController<bool>.broadcast();
+
+  AccessibilityController({required this.options});
+
+  Stream<bool> getStream() => _controller.stream;
+
+  final _accessibilityConfigKey =
+      "UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH";
+
+  /// The path at which the accessibility INI file is written.
+  /// Reads the [ACCESSIBILITY_CONFIG_PATH] environment variable; returns an
+  /// empty string (disabling file I/O) if the variable is not set.
+  String get _configPath => Platform.environment[_accessibilityConfigKey] ?? '';
+
+  /// Reads the accessibility config file on disk and sets each option's
+  /// current value. Options absent from the file, or with an unrecognised
+  /// value, are left at their default (index 0).
+  Future<void> initialize() async {
+    if (_configPath.isEmpty) {
+      _logger.warning(
+          '$_accessibilityConfigKey is not set; skipping startup read');
+      return;
+    }
+
+    final file = File(_configPath);
+    if (!await file.exists()) {
+      _logger.info('No accessibility config file found at $_configPath; '
+          'all options will use their defaults');
+      return;
+    }
+
+    final Map<String, String> storedValues = {};
+    try {
+      final contents = await file.readAsString();
+      final config = Config.fromString(contents);
+      const section = 'default';
+      for (final key in config.options(section)!) {
+        storedValues[key] = config.get(section, key)!;
+      }
+    } catch (e, stackTrace) {
+      _logger.shout('Failed to read accessibility config from $_configPath', e,
+          stackTrace);
+      return;
+    }
+
+    for (final option in options) {
+      final stored = storedValues[option.id];
+      if (stored == null) {
+        _logger
+            .info('Option "${option.id}" not found in config; keeping default');
+        continue;
+      }
+      final applied = option.setValueFromString(stored);
+      if (applied) {
+        _logger
+            .info('Option "${option.id}" initialised to "$stored" from config');
+      } else {
+        _logger.warning(
+            'Option "${option.id}" stored value "$stored" is not in the '
+            'allowed values list ${option.values}; keeping default');
+      }
+    }
+  }
+
+  void expand() {
+    _logger.info('Accessibility panel expanded');
+    _isExpanded = true;
+    _controller.add(true);
+  }
+
+  void collapse() {
+    _logger.info('Accessibility panel collapsed');
+    _isExpanded = false;
+    _controller.add(false);
+  }
+
+  void cycleForward(AccessibilityOption option) {
+    option.cycleForward();
+    _logger.info(
+        'Option "${option.label}" cycled forward -> "${option.currentValue}"');
+    _writeCurrentConfig();
+  }
+
+  void cycleBackward(AccessibilityOption option) {
+    option.cycleBackward();
+    _logger.info(
+        'Option "${option.label}" cycled backward -> "${option.currentValue}"');
+    _writeCurrentConfig();
+  }
+
+  Future<void> _writeCurrentConfig() async {
+    if (_configPath.isEmpty) {
+      _logger.warning('ACCESSIBILITY_CONFIG_PATH is not set; skipping write');
+      return;
+    }
+
+    final buffer = StringBuffer();
+    for (final opt in options) {
+      buffer.writeln('${opt.id} = ${opt.currentValue}');
+    }
+
+    try {
+      final file = File(_configPath);
+      await file.parent.create(recursive: true);
+      await file.writeAsString(buffer.toString());
+      _logger.info('Wrote accessibility config to $_configPath');
+    } catch (e) {
+      _logger.shout('Failed to write accessibility config to $_configPath: $e');
+    }
+  }
+}

--- a/launcher/lib/main.dart
+++ b/launcher/lib/main.dart
@@ -23,11 +23,16 @@ import 'package:get_it/get_it.dart';
 import 'views/dock.dart';
 import 'controllers/application_controller.dart';
 import 'package:logging/logging.dart';
+import 'package:ubuntu_frame_launcher/controllers/accessibility_controller.dart';
 
 void main() async {
   Logger.root.level = Level.ALL; // defaults to Level.INFO
   Logger.root.onRecord.listen((record) {
     print('${record.level.name}: ${record.time}: ${record.message}');
+    if (record.error != null) print('  Error: ${record.error}');
+    if (record.stackTrace != null) {
+      print('  Stack trace:\n${record.stackTrace}');
+    }
   });
 
   final logger = Logger("main");
@@ -47,6 +52,10 @@ void main() async {
   getIt.registerLazySingleton<WindowController>(
       () => WindowController(getIt.get<WindowService>()));
 
+  getIt.registerSingletonAsync<AccessibilityController>(
+      () => AccessibilityController.create());
+
+  await getIt.allReady();
   runApp(const LauncherApp());
 }
 

--- a/launcher/lib/main.dart
+++ b/launcher/lib/main.dart
@@ -23,11 +23,17 @@ import 'package:get_it/get_it.dart';
 import 'views/dock.dart';
 import 'controllers/application_controller.dart';
 import 'package:logging/logging.dart';
+import 'package:ubuntu_frame_launcher/controllers/accessibility_controller.dart';
+import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
 
 void main() async {
   Logger.root.level = Level.ALL; // defaults to Level.INFO
   Logger.root.onRecord.listen((record) {
     print('${record.level.name}: ${record.time}: ${record.message}');
+    if (record.error != null) print('  Error: ${record.error}');
+    if (record.stackTrace != null) {
+      print('  Stack trace:\n${record.stackTrace}');
+    }
   });
 
   final logger = Logger("main");
@@ -39,13 +45,35 @@ void main() async {
   getIt.registerLazySingleton<WindowService>(
       () => WindowService(WaylandWindowWatcherService()));
   getIt.registerLazySingleton<DesktopFileManager>(() => DesktopFileManager());
-
   // Controllers
   getIt.registerLazySingleton<ApplicationController>(() =>
       ApplicationController(
           getIt.get<WindowService>(), getIt.get<DesktopFileManager>()));
   getIt.registerLazySingleton<WindowController>(
       () => WindowController(getIt.get<WindowService>()));
+  getIt.registerLazySingleton<AccessibilityController>(
+      () => AccessibilityController(options: [
+            AccessibilityOption(
+              id: 'magnifier_enable',
+              label: 'Zoom',
+              icon: Icons.zoom_in,
+              values: ['true', 'false'],
+            ),
+            AccessibilityOption(
+              id: 'output_filter',
+              label: 'Screen Filter',
+              icon: Icons.filter_b_and_w,
+              values: ['none', 'grayscale', 'invert'],
+            ),
+            AccessibilityOption(
+              id: 'cursor_scale',
+              label: 'Cursor Scale',
+              icon: Icons.mouse_outlined,
+              values: ['1', '1.5', '2'],
+            ),
+          ]));
+
+  await getIt.get<AccessibilityController>().initialize();
 
   runApp(const LauncherApp());
 }

--- a/launcher/lib/models/accessibility_option.dart
+++ b/launcher/lib/models/accessibility_option.dart
@@ -1,0 +1,66 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class AccessibilityOption {
+  final String id;
+  final String label;
+  final IconData icon;
+  final List<String> values;
+  int _currentIndex;
+
+  final _controller = StreamController<String>.broadcast();
+
+  AccessibilityOption({
+    required this.id,
+    required this.label,
+    required this.icon,
+    required this.values,
+    int currentIndex = 0,
+  })  : assert(values.isNotEmpty),
+        _currentIndex = currentIndex;
+
+  int get currentIndex => _currentIndex;
+  String get currentValue => values[_currentIndex];
+
+  Stream<String> getStream() => _controller.stream;
+
+  /// Sets the current value by matching [value] against [values].
+  /// Returns true if a match was found, false otherwise.
+  bool setValueFromString(String value) {
+    final index = values.indexOf(value);
+    if (index == -1) return false;
+    _currentIndex = index;
+    return true;
+  }
+
+  void cycleForward() {
+    _currentIndex = (_currentIndex + 1) % values.length;
+    _controller.add(values[_currentIndex]);
+  }
+
+  void cycleBackward() {
+    _currentIndex = (_currentIndex - 1 + values.length) % values.length;
+    _controller.add(values[_currentIndex]);
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/launcher/lib/models/accessibility_option.dart
+++ b/launcher/lib/models/accessibility_option.dart
@@ -1,0 +1,53 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter/material.dart';
+
+class AccessibilityOption {
+  final String id;
+
+  /// The key used when writing/reading this option's value in the Mir
+  /// accessibility config override file. Defaults to [id] if not provided.
+  final String configKey;
+
+  final IconData icon;
+  final List<String> values;
+  int _currentIndex = 0;
+
+  AccessibilityOption({
+    required this.id,
+    String? configKey,
+    required this.icon,
+    required this.values,
+  })  : configKey = configKey ?? id,
+        assert(values.isNotEmpty);
+
+  String get currentValue => values[_currentIndex];
+
+  void setValueFromString(String value) {
+    final index = values.indexOf(value);
+    if (index == -1) return;
+    _currentIndex = index;
+  }
+
+  void cycleForward() {
+    _currentIndex = (_currentIndex + 1) % values.length;
+  }
+
+  void cycleBackward() {
+    _currentIndex = (_currentIndex - 1 + values.length) % values.length;
+  }
+}

--- a/launcher/lib/models/accessibility_option.dart
+++ b/launcher/lib/models/accessibility_option.dart
@@ -43,11 +43,10 @@ class AccessibilityOption {
 
   /// Sets the current value by matching [value] against [values].
   /// Returns true if a match was found, false otherwise.
-  bool setValueFromString(String value) {
+  void setValueFromString(String value) {
     final index = values.indexOf(value);
-    if (index == -1) return false;
+    if (index == -1) return;
     _currentIndex = index;
-    return true;
   }
 
   void cycleForward() {

--- a/launcher/lib/views/accessibility_button.dart
+++ b/launcher/lib/views/accessibility_button.dart
@@ -1,0 +1,318 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:ubuntu_frame_launcher/controllers/accessibility_controller.dart';
+import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
+import 'package:ubuntu_frame_launcher/views/launcher_button.dart';
+
+// Duration for the overall panel open/close animation.
+const _kPanelDuration = Duration(milliseconds: 250);
+
+// Duration for each option button's staggered fade-in.
+const _kOptionFadeDuration = Duration(milliseconds: 180);
+
+// Delay between each successive option button fading in.
+const _kStaggerOffset = Duration(milliseconds: 40);
+
+// Delay to let option fades begin before the panel closes.
+const _kCollapseDelay = Duration(milliseconds: 80);
+
+class AccessibilityButton extends StatefulWidget {
+  const AccessibilityButton({super.key});
+
+  @override
+  State<AccessibilityButton> createState() => _AccessibilityButtonState();
+}
+
+class _AccessibilityButtonState extends State<AccessibilityButton>
+    with TickerProviderStateMixin {
+  final _controller = GetIt.instance.get<AccessibilityController>();
+
+  // Drives the panel height (SizeTransition) and icon rotation.
+  late final AnimationController _panelAnim;
+
+  // One animation controller per option for staggered fades.
+  late final List<AnimationController> _optionAnims;
+
+  late final StreamSubscription<bool> _expandSubscription;
+
+  // Incremented on every expand/collapse; lets async methods detect they
+  // have been superseded by a newer call and bail out early.
+  int _animGeneration = 0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _panelAnim = AnimationController(
+      vsync: this,
+      duration: _kPanelDuration,
+    );
+
+    _optionAnims = List.generate(
+      _controller.options.length,
+      (_) => AnimationController(
+        vsync: this,
+        duration: _kOptionFadeDuration,
+      ),
+    );
+
+    _expandSubscription = _controller.getStream().listen(_onExpandedChanged);
+  }
+
+  @override
+  void dispose() {
+    _expandSubscription.cancel();
+    _panelAnim.dispose();
+    for (final a in _optionAnims) {
+      a.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onExpandedChanged(bool isExpanded) {
+    if (isExpanded) {
+      _playExpand();
+    } else {
+      _playCollapse();
+    }
+  }
+
+  void _playExpand() async {
+    final gen = ++_animGeneration;
+
+    // Panel grows open first.
+    _panelAnim.forward();
+
+    // Then stagger each option button in.
+    for (int i = 0; i < _optionAnims.length; i++) {
+      _optionAnims[i].reset();
+      await Future.delayed(_kStaggerOffset);
+      if (!mounted || _animGeneration != gen) return;
+      _optionAnims[i].forward();
+    }
+  }
+
+  void _playCollapse() async {
+    final gen = ++_animGeneration;
+
+    // Fade options out quickly, then close the panel.
+    for (final a in _optionAnims) {
+      a.reverse();
+    }
+    await Future.delayed(_kCollapseDelay);
+    if (!mounted || _animGeneration != gen) return;
+    _panelAnim.reverse();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // The expanding panel: size + fade wraps the option list.
+        SizeTransition(
+          sizeFactor: CurvedAnimation(
+            parent: _panelAnim,
+            curve: Curves.easeInOut,
+          ),
+          axisAlignment: -1.0,
+          child: FadeTransition(
+            opacity: CurvedAnimation(
+              parent: _panelAnim,
+              curve: const Interval(0.3, 1.0, curve: Curves.easeIn),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ..._controller.options.asMap().entries.map((entry) {
+                  final i = entry.key;
+                  final option = entry.value;
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: FadeTransition(
+                      opacity: CurvedAnimation(
+                        parent: _optionAnims[i],
+                        curve: Curves.easeIn,
+                      ),
+                      child: _OptionButton(
+                        option: option,
+                        onTap: () => _controller.cycleForward(option),
+                        onLongPress: () => _controller.cycleBackward(option),
+                      ),
+                    ),
+                  );
+                }),
+                const SizedBox(height: 4),
+              ],
+            ),
+          ),
+        ),
+
+        // The main accessibility icon button - always visible.
+        StreamBuilder(
+          stream: _controller.getStream(),
+          builder: (context, _) => LauncherButton(
+            onPressed: () {
+              if (_controller.isExpanded) {
+                _controller.collapse();
+              } else {
+                _controller.expand();
+              }
+            },
+            active: _controller.isExpanded,
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 200),
+              transitionBuilder: (child, anim) => FadeTransition(
+                opacity: anim,
+                child: ScaleTransition(scale: anim, child: child),
+              ),
+              child: Icon(
+                _controller.isExpanded
+                    ? Icons.keyboard_arrow_down
+                    : Icons.accessibility_new,
+                key: ValueKey(_controller.isExpanded),
+                color: Colors.white,
+                size: 32,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OptionButton extends StatefulWidget {
+  final AccessibilityOption option;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  const _OptionButton({
+    required this.option,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  @override
+  State<_OptionButton> createState() => _OptionButtonState();
+}
+
+class _OptionButtonState extends State<_OptionButton> {
+  bool _mouseOver = false;
+  // true = incoming value slides in from the right (tap/forward),
+  // false = incoming value slides in from the left (long press/backward).
+  bool _slideFromRight = true;
+
+  @override
+  Widget build(BuildContext context) {
+    // StreamBuilder is scoped to this option only, so cycling one
+    // option does not cause sibling buttons to rebuild.
+    return StreamBuilder(
+      stream: widget.option.getStream(),
+      builder: (context, _) {
+        return Tooltip(
+          message: '${widget.option.label}: ${widget.option.currentValue}',
+          preferBelow: false,
+          textStyle: const TextStyle(fontSize: 10, color: Colors.white),
+          child: MouseRegion(
+            onEnter: (_) => setState(() => _mouseOver = true),
+            onExit: (_) => setState(() => _mouseOver = false),
+            child: GestureDetector(
+              onTap: () {
+                setState(() => _slideFromRight = true);
+                widget.onTap();
+              },
+              onLongPress: () {
+                setState(() => _slideFromRight = false);
+                widget.onLongPress();
+              },
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(14),
+                  color: Color.fromARGB(_mouseOver ? 63 : 20, 255, 255, 255),
+                ),
+                alignment: Alignment.center,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      widget.option.icon,
+                      color: Colors.white,
+                      size: 22,
+                    ),
+                    const SizedBox(height: 2),
+                    AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 200),
+                      // Incoming widget slides in from one side,
+                      // outgoing widget slides out the opposite side.
+                      transitionBuilder: (child, anim) {
+                        final isIncoming =
+                            child.key == ValueKey(widget.option.currentValue);
+                        final incomingOffset =
+                            Offset(_slideFromRight ? 1.0 : -1.0, 0.0);
+                        final outgoingOffset =
+                            Offset(_slideFromRight ? -1.0 : 1.0, 0.0);
+                        return ClipRect(
+                          child: SlideTransition(
+                            position: Tween<Offset>(
+                              begin:
+                                  isIncoming ? incomingOffset : outgoingOffset,
+                              end: Offset.zero,
+                            ).animate(CurvedAnimation(
+                              parent: anim,
+                              curve: Curves.easeInOut,
+                            )),
+                            child: child,
+                          ),
+                        );
+                      },
+                      layoutBuilder: (currentChild, previousChildren) => Stack(
+                        alignment: Alignment.center,
+                        children: [
+                          ...previousChildren,
+                          if (currentChild != null) currentChild,
+                        ],
+                      ),
+                      child: Text(
+                        widget.option.currentValue,
+                        key: ValueKey(widget.option.currentValue),
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 9,
+                          fontFamily: 'Ubuntu',
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/launcher/lib/views/accessibility_button.dart
+++ b/launcher/lib/views/accessibility_button.dart
@@ -1,0 +1,90 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:ubuntu_frame_launcher/controllers/accessibility_controller.dart';
+import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
+
+class AccessibilityButton extends StatelessWidget {
+  const AccessibilityButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = GetIt.instance.get<AccessibilityController>();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ...controller.options.map(
+          (option) => Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: _OptionButton(
+              option: option,
+              onTap: () => controller.cycleForward(option),
+              onLongPress: () => controller.cycleBackward(option),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OptionButton extends StatefulWidget {
+  final AccessibilityOption option;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  const _OptionButton({
+    required this.option,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  @override
+  State<_OptionButton> createState() => _OptionButtonState();
+}
+
+class _OptionButtonState extends State<_OptionButton> {
+  bool _mouseOver = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) => setState(() => _mouseOver = true),
+      onExit: (_) => setState(() => _mouseOver = false),
+      child: GestureDetector(
+        onTap: widget.onTap,
+        onLongPress: widget.onLongPress,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          width: 56,
+          height: 56,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(14),
+            color: Color.fromARGB(_mouseOver ? 63 : 20, 255, 255, 255),
+          ),
+          alignment: Alignment.center,
+          child: Icon(
+            widget.option.icon,
+            color: Colors.white,
+            size: 22,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/launcher/lib/views/dock.dart
+++ b/launcher/lib/views/dock.dart
@@ -17,6 +17,7 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:ubuntu_frame_launcher/controllers/application_controller.dart';
+import 'package:ubuntu_frame_launcher/views/accessibility_button.dart';
 import 'package:ubuntu_frame_launcher/views/dock_button.dart';
 import 'package:ubuntu_frame_launcher/views/stream_builder_with_future_initial_value.dart';
 
@@ -24,32 +25,39 @@ const double _dockWidthPx = 70;
 const _dockPadding = EdgeInsets.fromLTRB(3, 6, 3, 6);
 
 class Dock extends StatelessWidget {
-  final applicationControler = GetIt.instance.get<ApplicationController>();
-
-  Dock({super.key});
+  const Dock({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final applicationController = GetIt.instance.get<ApplicationController>();
     return Expanded(
-        child: Container(
-            color: Colors.black,
-            width: _dockWidthPx,
-            padding: _dockPadding,
-            child: StreamBuilderWithFutureInitialValue(
-                future: applicationControler.getOpenApplications(),
-                stream: applicationControler.getOpenedAppsStream(),
-                loader: const Row(),
-                builder: (context, openedApps) {
-                  List<Widget> dockButtons = [];
-                  for (final opened in openedApps) {
-                    if (opened.id.isEmpty) {
-                      continue;
+      child: Container(
+        color: Colors.black,
+        width: _dockWidthPx,
+        padding: _dockPadding,
+        child: Column(
+          children: [
+            Expanded(
+              child: StreamBuilderWithFutureInitialValue(
+                  future: applicationController.getOpenApplications(),
+                  stream: applicationController.getOpenedAppsStream(),
+                  loader: const Row(),
+                  builder: (context, openedApps) {
+                    List<Widget> dockButtons = [];
+                    for (final opened in openedApps) {
+                      if (opened.id.isEmpty) {
+                        continue;
+                      }
+                      dockButtons.add(DockButton(desktopFile: opened));
                     }
-                    dockButtons.add(DockButton(desktopFile: opened));
-                  }
-
-                  return SingleChildScrollView(
-                      child: Column(children: dockButtons));
-                })));
+                    return SingleChildScrollView(
+                        child: Column(children: dockButtons));
+                  }),
+            ),
+            const AccessibilityButton(),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/launcher/lib/views/dock.dart
+++ b/launcher/lib/views/dock.dart
@@ -17,39 +17,53 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:ubuntu_frame_launcher/controllers/application_controller.dart';
+import 'package:ubuntu_frame_launcher/views/accessibility_button.dart';
 import 'package:ubuntu_frame_launcher/views/dock_button.dart';
 import 'package:ubuntu_frame_launcher/views/stream_builder_with_future_initial_value.dart';
 
 const double _dockWidthPx = 70;
 const _dockPadding = EdgeInsets.fromLTRB(3, 6, 3, 6);
 
-class Dock extends StatelessWidget {
-  final applicationControler = GetIt.instance.get<ApplicationController>();
+class Dock extends StatefulWidget {
+  const Dock({super.key});
 
-  Dock({super.key});
+  @override
+  State<Dock> createState() => _DockState();
+}
+
+class _DockState extends State<Dock> {
+  final _applicationController = GetIt.instance.get<ApplicationController>();
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-        child: Container(
-            color: Colors.black,
-            width: _dockWidthPx,
-            padding: _dockPadding,
-            child: StreamBuilderWithFutureInitialValue(
-                future: applicationControler.getOpenApplications(),
-                stream: applicationControler.getOpenedAppsStream(),
-                loader: const Row(),
-                builder: (context, openedApps) {
-                  List<Widget> dockButtons = [];
-                  for (final opened in openedApps) {
-                    if (opened.id.isEmpty) {
-                      continue;
+      child: Container(
+        color: Colors.black,
+        width: _dockWidthPx,
+        padding: _dockPadding,
+        child: Column(
+          children: [
+            Expanded(
+              child: StreamBuilderWithFutureInitialValue(
+                  future: _applicationController.getOpenApplications(),
+                  stream: _applicationController.getOpenedAppsStream(),
+                  loader: const Row(),
+                  builder: (context, openedApps) {
+                    List<Widget> dockButtons = [];
+                    for (final opened in openedApps) {
+                      if (opened.id.isEmpty) {
+                        continue;
+                      }
+                      dockButtons.add(DockButton(desktopFile: opened));
                     }
-                    dockButtons.add(DockButton(desktopFile: opened));
-                  }
-
-                  return SingleChildScrollView(
-                      child: Column(children: dockButtons));
-                })));
+                    return SingleChildScrollView(
+                        child: Column(children: dockButtons));
+                  }),
+            ),
+            const AccessibilityButton(),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/scripts/bin/run-launcher
+++ b/scripts/bin/run-launcher
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu
+
+# Translate launcher.tail snap config into the env var the launcher reads.
+# snapctl get launcher.tail already returns a comma-separated list.
+launcher_tail="$(snapctl get launcher.tail)"
+export UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_OPTIONS="${launcher_tail}"
+
+exec "$@"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -134,8 +134,47 @@ else
   snapctl stop --disable "$SNAP_INSTANCE_NAME.daemon" 2>&1 || true
 fi
 
+# Validate and process launcher option
+# launcher can be: "true", "false", or a JSON object e.g. {"tail":["magnifier","cursor-scale"]}
+# When set as an object, snapctl exposes launcher.tail as a comma-separated list already.
+launcher_val="$(snapctl get launcher)"
+launcher_enabled=false
+case "$launcher_val" in
+  true)
+    launcher_enabled=true
+    ;;
+  false|"")
+    launcher_enabled=false
+    ;;
+  {*)
+    launcher_enabled=true
+    ;;
+  *)
+    echo "ERROR: launcher must be true, false, or a JSON object"
+    exit 1
+    ;;
+esac
+
+validate_launcher_tail() {
+  local tail="$1"
+  [ -z "$tail" ] && return 0
+  local IFS=','
+  for element in $tail; do
+    case "$element" in
+      magnifier|cursor-scale|output-filter) ;;
+      *) return 1 ;;
+    esac
+  done
+  return 0
+}
+launcher_tail="$(snapctl get launcher.tail)"
+if ! validate_launcher_tail "$launcher_tail"; then
+  echo "ERROR: launcher.tail must be a list of zero or more of: magnifier, cursor-scale, output-filter"
+  exit 1
+fi
+
 # Start or stop the launcher
-if [ "$(snapctl get launcher)" = "true" ]; then
+if [ "$launcher_enabled" = "true" ]; then
   ARCH=$(uname -m)
   if [[ "$ARCH" != @(x86_64*|i*86|aarch64) ]]; then
     echo "Cannot enable the launcher on $ARCH system"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,8 @@ environment:
   # Setup diagnostic
   MIR_SERVER_DIAGNOSTIC_PATH: $SNAP_COMMON/diagnostic/diagnostic.txt
   XDG_CURRENT_DESKTOP: UbuntuFrame:Mir
+  # Shared accessibility config path between frame and launcher
+  UBUNTU_FRAME_ACCESSIBILITY_CONFIG_PATH: $SNAP_COMMON/accessibility.ini
 
 layout:
   /usr/share/icons:
@@ -55,6 +57,7 @@ apps:
 
   launcher:
     command-chain:
+      - bin/run-launcher
       - bin/wayland-launch
       - bin/gpu-2404-wrapper
     command: ubuntu_frame_launcher

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 project(ubuntu-frame)
 include(FindPkgConfig)
 include(CMakeDependentOption)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ubuntu-frame)
 include(FindPkgConfig)
 include(CMakeDependentOption)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -71,15 +71,16 @@ int main(int argc, char const* argv[])
     miral::OutputFilter output_filter{ini_files};
     miral::Magnifier magnifier{ini_files};
 
-    auto const xdg_config_home = []() -> std::filesystem::path
+    auto const accessibility_config_path = []() -> std::filesystem::path
     {
+        if (auto const* env_path = std::getenv("UBUNTU_FRAME_ACCESSIBILITY_CONFIG_PATH"); env_path && *env_path)
+            return env_path;
         if (auto const* xdg = std::getenv("XDG_CONFIG_HOME"); xdg && *xdg)
-            return xdg;
+            return std::filesystem::path{xdg} / "mir" / "accessibility.ini";
         if (auto const* home = std::getenv("HOME"); home && *home)
-            return std::filesystem::path{home} / ".config";
-        return ".config";
+            return std::filesystem::path{home} / ".config" / "mir" / "accessibility.ini";
+        return ".config/mir/accessibility.ini";
     }();
-    auto const accessibility_config_path = xdg_config_home / "mir" / "accessibility.ini";
 
     miral::ConfigFile config_file{
         runner, accessibility_config_path,

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -30,6 +30,20 @@
 #include <miral/set_window_management_policy.h>
 #include <miral/wayland_extensions.h>
 
+#include <miral/version.h>
+
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 9, 0)
+#include <miral/live_config_ini_file.h>
+#include <miral/cursor_scale.h>
+#include <miral/output_filter.h>
+#include <miral/magnifier.h>
+#include <miral/config_file.h>
+#include <miral/live_config_ini_file_with_overrides.h>
+
+#include <cstdlib>
+#include <filesystem>
+#endif
+
 int main(int argc, char const* argv[])
 {
     using namespace miral;
@@ -50,6 +64,31 @@ int main(int argc, char const* argv[])
     runner.add_stop_callback([&] { background_client.stop(); });
     auto display_config = build_display_configuration(runner);
 
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 9, 0)
+    miral::live_config::IniFileWithOverrides ini_files;
+
+    miral::CursorScale cursor_scale{ini_files};
+    miral::OutputFilter output_filter{ini_files};
+    miral::Magnifier magnifier{ini_files};
+
+    auto const xdg_config_home = []() -> std::filesystem::path
+    {
+        if (auto const* xdg = std::getenv("XDG_CONFIG_HOME"); xdg && *xdg)
+            return xdg;
+        if (auto const* home = std::getenv("HOME"); home && *home)
+            return std::filesystem::path{home} / ".config";
+        return ".config";
+    }();
+    auto const accessibility_config_path = xdg_config_home / "mir" / "accessibility.ini";
+
+    miral::ConfigFile config_file{
+        runner, accessibility_config_path,
+        miral::ConfigFile::Mode::reload_on_change,
+        [&ini_files](miral::live_config::OverridesList const &overrides) {
+          ini_files.load(overrides);
+        },
+        ".ini"};
+#endif
     return runner.run_with(
         {
             wayland_extensions,
@@ -76,6 +115,11 @@ int main(int argc, char const* argv[])
                 window_manager_observer,
                 display_config),
             Keymap{},
-            miral::Decorations::always_csd()
+            miral::Decorations::always_csd(),
+#if MIRAL_VERSION >= MIR_VERSION_NUMBER(5, 9, 0)
+            cursor_scale,
+            output_filter,
+            magnifier,
+#endif
         });
 }

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -29,6 +29,15 @@
 #include <miral/set_window_management_policy.h>
 #include <miral/wayland_extensions.h>
 
+#include <miral/config_aggregator.h>
+
+#include <miral/config_file_store_adapter.h>
+#include <miral/live_config_ini_file.h>
+#include <miral/cursor_scale.h>
+#include <miral/output_filter.h>
+#include <miral/magnifier.h>
+#include <miral/config_file.h>
+
 int main(int argc, char const* argv[])
 {
     using namespace miral;
@@ -44,6 +53,32 @@ int main(int argc, char const* argv[])
     runner.add_stop_callback([&] { background_client.stop(); });
     auto display_config = build_display_configuration(runner);
 
+    miral::live_config::ConfigAggregator config_aggregator{};
+    miral::ConfigFileStoreAdapter adapter{
+        config_aggregator,
+        [](std::unique_ptr<std::istream> stream, std::filesystem::path const& path)
+        {
+            auto parser = std::make_shared<miral::live_config::IniFile>();
+            return miral::live_config::ConfigAggregator::Source{
+                parser,
+                [parser, stream = std::move(stream), path]()
+                {
+                    parser->load_file(*stream, path);
+                },
+                path,
+            };
+        }};
+
+    miral::CursorScale cursor_scale{config_aggregator};
+    miral::OutputFilter output_filter{config_aggregator};
+    miral::Magnifier magnifier{config_aggregator};
+
+    miral::ConfigFile config_file{
+        runner,
+        "/home/tarek.ismail@canonical.com/.config/mir/accessibility.ini",
+        miral::ConfigFile::Mode::reload_on_change,
+        [&adapter](auto args) { adapter(args); },
+    };
     return runner.run_with(
         {
             wayland_extensions,
@@ -70,6 +105,9 @@ int main(int argc, char const* argv[])
                 window_manager_observer,
                 display_config),
             Keymap{},
-            miral::Decorations::always_csd()
+            miral::Decorations::always_csd(),
+            cursor_scale,
+            output_filter,
+            magnifier
         });
 }


### PR DESCRIPTION
## What's new

- Add's a mini accessibility launcher/widget that communicates with Ubuntu Frame via a config override file

## How to test

First, you need to get a version of Mir with support for live config override, you can use the code corresponding to this PR: https://github.com/canonical/mir/pull/4781

To build a local copy, run the following bash commands:
```
cmake -B build -DCMAKE_INSTALL_PREFIX=~/mir-local-install
cmake --build build -j$(nproc)
cmake --install build
```

Second, build Ubuntu frame from this PR with the following commands. This will use the version you just built and installed:
```
PKG_CONFIG_PATH=~/mir-local-install/lib/pkgconfig:~/mir-local-install/lib/x86_64-linux-gnu/pkgconfig  \
  cmake -B src/build src/
cmake --build src/build -j$(nproc)
```
(Tell me if there's a better way)

Then, run Ubuntu Frame and the launcher:
```
# Terminal 1 – start your locally built ubuntu-frame binary
WAYLAND_DISPLAY=wayland-98 /path/to/ubuntu-frame/src/build/frame \
  --add-wayland-extensions zwlr_layer_shell_v1:zwlr_foreign_toplevel_manager_v1

# Terminal 2 – run the launcher against the same socket
cd /path/to/ubuntu-frame/launcher
UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_CONFIG_PATH=~/.config/mir/accessibility.ini.d/launcher-override.conf WAYLAND_DISPLAY=wayland-98 flutter run
```

Now, you should have the Ubuntu Frame with the launcher inside of it. Tapping, or pressing and holding options should cycle forwards and backwards, with effects applying immediately.

You can additionally pass an environment variable `UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_OPTIONS=<option>,<another option>,...` to constrain the options available to users. By default, if the variable is empty, then no options are shown. If it's not present, all options are shown.