### PR TITLE
Add support for the plymouth-replace interface

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Build and publish the snap
       uses: canonical/actions/build-snap@78e8dd5f693653767f2c60c4a6a421a1ebed35af # release @ 2025.06.05
       with:
+        snapcraft-channel: edge
         architecture: ${{ matrix.platform }}
         snapcraft-token: ${{ secrets.SNAPCRAFT_TOKEN }}
         launchpad-credentials: ${{ secrets.LAUNCHPAD_CREDENTIALS }}

--- a/docs/how-to/using-ubuntu-frame/get-a-smooth-boot-experience.md
+++ b/docs/how-to/using-ubuntu-frame/get-a-smooth-boot-experience.md
@@ -34,19 +34,10 @@ sudo snap install wpe-webkit-mir-kiosk
 
 By default, Plymouth (the daemon responsible for the splash screen) quits at the end of the boot process. We need to prevent that, but make it release the GPU resources so that Frame can take over.
 
-To do this, we'll add the following changes to the Ubuntu Frame daemon service, either via `sudo systemctl edit snap.ubuntu-frame.daemon.service` or just dropping these lines into the file:
+To do this, we'll connect the `plymouth-replace` interface:
 
-```ini
-# /etc/systemd/system/snap.ubuntu-frame.daemon.service.d/override.conf
-[Unit]
-Conflicts=plymouth-quit.service
-After=plymouth-quit.service
-OnFailure=plymouth-quit.service
-
-[Service]
-ExecStartPre=-/usr/bin/plymouth deactivate
-ExecStartPost=/usr/bin/sleep 10
-ExecStartPost=-/usr/bin/plymouth quit --retain-splash
+```shell
+sudo snap connect ubuntu-frame:plymouth-replace
 ```
 
 Another change we want to do is tell Ubuntu Frame to not draw its wallpaper, and run on the first virtual terminal:
@@ -73,27 +64,8 @@ Refer to the relevant documentation for how to {ref}`configure Frame <configurin
       config: |
         vt=1
         wallpaper=false
-  ```
-
-- One way to include the necessary service changes is by {doc}`including cloud-init configuration <core:reference/gadget-snap-format>` in the gadget snap:
-
-  ```
-  # cloud.conf
-  #cloud-config
-  datasource_list: [NoCloud]
-
-  write_files:
-  - path: '/etc/systemd/system/snap.ubuntu-frame.daemon.service.d/override.conf'
-    content: |
-      [Unit]
-      Conflicts=plymouth-quit.service
-      After=plymouth-quit.service
-      OnFailure=plymouth-quit.service
-
-      [Service]
-      ExecStartPre=-/usr/bin/plymouth deactivate
-      ExecStartPost=/usr/bin/sleep 10
-      ExecStartPost=-/usr/bin/plymouth quit --retain-splash
+  connections:
+    - plug: BPZbvWzvoMTrpec4goCXlckLe2IhfthK:plymouth-replace
   ```
 
 ## Display configuration

--- a/scripts/bin/run-daemon
+++ b/scripts/bin/run-daemon
@@ -6,6 +6,12 @@ then
   initialise-display-config&
 fi
 
+# Try to deactivate plymouth. This can only succeed when the
+# plymouth-replace plug is connected.
+if plymouth deactivate 2>/dev/null; then
+    sh -c 'sleep 10; plymouth quit --retain-splash' & disown
+fi
+
 # Unblock racy clients that hang https://github.com/canonical/ubuntu-frame/issues/130
 sh -c 'sleep 5; mkdir "/run/user/007"; rmdir "/run/user/007"'& disown
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,6 +4,8 @@ summary: The foundation for many embedded graphical display implementations
 description: ubuntu-frame is a simple fullscreen shell (based on Wayland) used for kiosks, industrial displays, digital signage, smart mirrors, etc.
 confinement: strict
 base: core26
+build-base: devel
+grade: devel
 license: GPL-3.0
 compression: lzo
 package-repositories:
@@ -102,7 +104,7 @@ plugs:
   gpu-2604:
     interface: content
     target: $SNAP/gpu-2604
-    default-provider: mesa-2604
+    # default-provider: mesa-2604
   wayplug:
     interface: wayland
 
@@ -122,7 +124,7 @@ parts:
       git config --global --add safe.directory ${CRAFT_PROJECT_DIR}
       recipe_version=`git -C ${CRAFT_PROJECT_DIR} rev-list --count HEAD`
       craftctl set version=$recipe_version-mir$mir_version
-      if echo $mir_version | grep -e '+dev' -e '~rc' -q; then craftctl set grade=devel; else craftctl set grade=stable; fi
+      #if echo $mir_version | grep -e '+dev' -e '~rc' -q; then craftctl set grade=devel; else craftctl set grade=stable; fi
     plugin: cmake
     cmake-parameters:
       - -DENABLE_TESTING=OFF

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,6 +87,7 @@ apps:
       - hardware-observe      # libinput likes to scan udev
       - opengl
       - desktop-launch
+      - plymouth-replace
     slots:
       - wayland
 


### PR DESCRIPTION
This PR is intended to work together with https://github.com/canonical/snapd/pull/16962 to achieve flicker-free boot purely managed from the snap.

If the snap declaration from the snapd PR is accepted, the `plymouth-replace` interface will be `allow-installation: false`, so we would need a snap declaration to allow the ubuntu-frame snap to be installable. I'm unsure whether we'd want to request auto-connection.