### PR TITLE
Add note for section placement in snap graphics

### DIFF
--- a/docs/how-to/use-snap-graphics.md
+++ b/docs/how-to/use-snap-graphics.md
@@ -57,7 +57,8 @@ Please check out the code for your specific extension [here](https://github.com/
        target: $SNAP/gpu-2404
        default-provider: mesa-2404
    ```
-Note: this section must be inserted before 'parts:' and 'apps:'.
+
+   Note: this must be inserted as a {ref}`top-level plugs: entry <snapcraft:project.plugs>`.
 
 {#gpu-2404-x11-layouts}
 

--- a/docs/how-to/use-snap-graphics.md
+++ b/docs/how-to/use-snap-graphics.md
@@ -57,6 +57,7 @@ Please check out the code for your specific extension [here](https://github.com/
        target: $SNAP/gpu-2404
        default-provider: mesa-2404
    ```
+Note: this section must be inserted before 'parts:' and 'apps:'.
 
 {#gpu-2404-x11-layouts}
 


### PR DESCRIPTION
Added a note about section placement for 'plugs:' support.

As suggested by Saviq, there: https://github.com/canonical/ubuntu-frame/issues/319